### PR TITLE
added migrator

### DIFF
--- a/Migrator/RouteCompilerClassMigrator.php
+++ b/Migrator/RouteCompilerClassMigrator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Migrator;
+
+use Doctrine\Bundle\PHPCRBundle\Migrator\AbstractMigrator;
+
+use PHPCR\ItemInterface;
+use PHPCR\NodeInterface;
+
+use PHPCR\Util\TreeWalker;
+
+class RouteCompilerClassMigrator extends AbstractMigrator
+{
+    /**
+     * @var int
+     */
+    private $count = 0;
+
+    public function migrate($identifer = '/', $depth = -1)
+    {
+        $walker = new TreeWalker($this);
+        $node = $this->session->getNodeByIdentifier($identifer);
+        $walker->traverse($node, $depth);
+        $this->session->save();
+
+        $this->output->write('Updated '.$this->count.' routes', true);
+
+        return 0;
+    }
+
+    protected function entering(ItemInterface $item, $depth)
+    {
+        if ($item instanceof NodeInterface) {
+            if ($item->hasProperty('phpcr:class')
+                && (is_subclass_of($item->getPropertyValue('phpcr:class'), 'Symfony\Cmf\Bundle\RoutingExtraBundle\Document\Route')
+                    || 'Symfony\Cmf\Bundle\RoutingExtraBundle\Document\Route' === $item->getPropertyValue('phpcr:class')
+                )
+            ) {
+                $options = $item->hasProperty('options') ? $item->getPropertyValue('options') : array();
+                $optionKeys = $item->hasProperty('optionKeys') ? $item->getPropertyValue('optionKeys') : array();
+
+                if (!in_array('Symfony\Component\Routing\RouteCompiler', $options)) {
+                    $options[] = 'Symfony\Component\Routing\RouteCompiler';
+                    $optionKeys[] = 'compiler_class';
+
+                    $item->setProperty('options', $options);
+                    $item->setProperty('optionKeys', $optionKeys);
+                    $this->output->write("Path: ".$item->getPath(), true);
+                    $this->count++;
+                }
+            }
+        }
+    }
+
+    protected function leaving(ItemInterface $item, $depth)
+    {
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,5 +18,9 @@
             <argument type="service" id="security.context" on-invalid="ignore"/>
         </service>
 
+        <service id="symfony_cmf_core.migrate.migrator.route_compiler_class" class="Symfony\Cmf\Bundle\CoreBundle\Migrator\RouteCompilerClassMigrator">
+            <tag name="doctrine_phpcr.migrator" alias="routing_compiler_class"/>
+        </service>
+
     </services>
 </container>


### PR DESCRIPTION
this adds a migrator command a way to register migrators. it also features a migrator command to handle the BC break caused by https://github.com/symfony-cmf/RoutingExtraBundle/commit/481ea824ee9c3c53c4d598bc4e9f1069b7411d5a 

see also https://github.com/symfony-cmf/RoutingExtraBundle/issues/40#issuecomment-10791258
