### PR TITLE
added PublishWorkflowListener

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,6 +16,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('document_manager_name')->defaultValue('default')->end()
                 ->scalarNode('role')->defaultValue('IS_AUTHENTICATED_ANONYMOUSLY')->end()
+                ->booleanNode('publish_workflow_listener')->defaultFalse()->end()
             ->end()
         ;
 

--- a/DependencyInjection/SymfonyCmfCoreExtension.php
+++ b/DependencyInjection/SymfonyCmfCoreExtension.php
@@ -3,6 +3,7 @@
 namespace Symfony\Cmf\Bundle\CoreBundle\DependencyInjection;
 
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
@@ -18,5 +19,11 @@ class SymfonyCmfCoreExtension extends Extension
 
         $container->setParameter($this->getAlias().'.role', $config['role']);
         $container->setParameter($this->getAlias() . '.document_manager_name', $config['document_manager_name']);
+
+        if (!$config['publish_workflow_listener']) {
+            $container->removeDefinition($this->getAlias() . '.publish_workflow_listener');
+        } elseif (!class_exists('Symfony\Cmf\Bundle\RoutingExtraBundle\Routing\DynamicRouter')) {
+            throw new InvalidConfigurationException("The 'publish_workflow_listener' may not be enabled unless 'Symfony\Cmf\Bundle\RoutingExtraBundle\Routing\DynamicRouter' is available.");
+        }
     }
 }

--- a/EventListener/PublishWorkflowListener.php
+++ b/EventListener/PublishWorkflowListener.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\CoreBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use Symfony\Cmf\Bundle\RoutingExtraBundle\Routing\DynamicRouter;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowCheckerInterface;
+
+/**
+ * Makes sure only published routes and content can be accessed
+ */
+class PublishWorkflowListener implements EventSubscriberInterface
+{
+    /**
+     * @var PublishWorkflowCheckerInterface
+     */
+    protected $publishWorkflowChecker;
+
+    /**
+     * @param PublishWorkflowCheckerInterface $publishWorkflowChecker
+     */
+    public function __construct(PublishWorkflowCheckerInterface $publishWorkflowChecker)
+    {
+        $this->publishWorkflowChecker = $publishWorkflowChecker;
+    }
+
+    /**
+     * Handling the request event
+     *
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        $route = $request->attributes->get(DynamicRouter::ROUTE_KEY);
+        if ($route && !$this->publishWorkflowChecker->checkIsPublished($route, false, $request)) {
+            throw new NotFoundHttpException('Route not found at: ' . $request->getPathInfo());
+        }
+
+        $content = $request->attributes->get(DynamicRouter::CONTENT_KEY);
+        if ($content && !$this->publishWorkflowChecker->checkIsPublished($content, false, $request)) {
+            throw new NotFoundHttpException('Content not found for: ' . $request->getPathInfo());
+        }
+    }
+
+    /**
+     * We are only interested in request events.
+     *
+     * @return array
+     */
+    static public function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array(array('onKernelRequest', 1)),
+        );
+    }
+
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,18 +4,29 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="symfony_cmf_core.twig_extension_class">Symfony\Cmf\Bundle\CoreBundle\Twig\TwigExtension</parameter>
+        <parameter key="symfony_cmf_core.publish_workflow_checker_class">Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker</parameter>
+        <parameter key="symfony_cmf_core.publish_workflow_listener_class">Symfony\Cmf\Bundle\CoreBundle\EventListener\PublishWorkflowListener</parameter>
+    </parameters>
+
     <services>
 
-        <service id="symfony_cmf_core.twig.children_extension" class="Symfony\Cmf\Bundle\CoreBundle\Twig\TwigExtension">
+        <service id="symfony_cmf_core.twig.children_extension" class="%symfony_cmf_core.twig_extension_class%">
             <argument type="service" id="symfony_cmf_core.publish_workflow_checker"/>
             <argument type="service" id="doctrine_phpcr" on-invalid="ignore" />
             <argument>%symfony_cmf_core.document_manager_name%</argument>
             <tag name="twig.extension"/>
         </service>
 
-        <service id="symfony_cmf_core.publish_workflow_checker" class="Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker">
+        <service id="symfony_cmf_core.publish_workflow_checker" class="%symfony_cmf_core.publish_workflow_checker_class%">
             <argument>%symfony_cmf_core.role%</argument>
             <argument type="service" id="security.context" on-invalid="ignore"/>
+        </service>
+
+        <service id="symfony_cmf_core.publish_workflow_listener" class="%symfony_cmf_core.publish_workflow_listener_class%">
+            <tag name="kernel.event_subscriber"/>
+            <argument type="service" id="symfony_cmf_core.publish_workflow_checker"/>
         </service>
 
     </services>

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "symfony/twig-bundle": "To get access to the CMF twig extension, >=2.1,<2.3-dev",
         "doctrine/phpcr-odm": "To be able to use the CMF twig extension, 1.0.*",
         "symfony/security-bundle": "To be able to use the publish worklow system, >=2.1,<2.3-dev",
-        "symfony-cmf/routing": "To be able to use the CMF twig extension functions cmf_prev_linkable/cmf_next_linkable, 1.0.*"
+        "symfony-cmf/routing": "To be able to use the CMF twig extension functions cmf_prev_linkable/cmf_next_linkable, 1.0.*",
+        "symfony-cmf/routing-extra-bundle": "To be able to enable the publish_workflow_listener, 1.0.*"
     },
     "autoload":{
         "psr-0":{


### PR DESCRIPTION
see https://github.com/symfony-cmf/RoutingExtraBundle/pull/58

we can then remove the logic from the `ContentController`:
https://github.com/symfony-cmf/ContentBundle/pull/22

i would suggest to not implement the `PublishWorkflowInterface` in the `Route`, maybe not even in the `StaticContent`/`Page` classes anymore. that being said .. while i want to keep the dependencies of RoutingExtraBundle as small as possible, I have no concern over the CoreBundle dependency in ContentBundle and SimpleCmsBundle

/cc @elHornair @dbu 
