### PR TITLE
twig prev next fixed

### DIFF
--- a/Twig/TwigExtension.php
+++ b/Twig/TwigExtension.php
@@ -6,6 +6,7 @@ use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowCheckerInterfac
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\Exception\MissingTranslationException;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use Symfony\Cmf\Component\Routing\RouteAwareInterface;
 
 class TwigExtension extends \Twig_Extension
 {
@@ -96,7 +97,7 @@ class TwigExtension extends \Twig_Extension
             if ($check) {
                 try {
                     $child = $this->dm->find(null, $parent->getPath().'/'.$name);
-                    if ($this->publishWorkflowChecker->checkIsPublished($child)) {
+                    if ($this->publishWorkflowChecker->checkIsPublished($child) && $child instanceof RouteAwareInterface) {
                         return $child;
                     }
                 } catch (MissingTranslationException $e) {


### PR DESCRIPTION
TwigExtension returns also elements like image etc from the current children list 

$child instanceof RouteAwareInterface

ensures that a route link can be generated 
