### PR TITLE
implemented cmf_descendants and depth support in cmf_next/cmf_prev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ php:
     - 5.4
 
 env:
-  - SYMFONY_VERSION=2.1.*
+#  - SYMFONY_VERSION=2.1.*
   - SYMFONY_VERSION=2.2.*
-  - SYMFONY_VERSION=dev-master
+#  - SYMFONY_VERSION=dev-master
 
 before_script:
   - composer require symfony/framework-bundle:${SYMFONY_VERSION}

--- a/Tests/Twig/TwigExtensionTest.php
+++ b/Tests/Twig/TwigExtensionTest.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Twig;
+
+use Symfony\Cmf\Bundle\CoreBundle\Twig\TwigExtension;
+
+class TwigExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    private $pwc;
+    private $managerRegistry;
+    private $manager;
+    private $uow;
+    private $extension;
+
+    public function setUp()
+    {
+        $this->pwc = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowCheckerInterface');
+
+        $this->managerRegistry = $this->getMockBuilder('Doctrine\Bundle\PHPCRBundle\ManagerRegistry')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getManager'))
+            ->getMock()
+        ;
+
+        $this->manager = $this->getMockBuilder('Doctrine\ODM\PHPCR\DocumentManager')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->managerRegistry->expects($this->any())
+            ->method('getManager')
+            ->with('foo')
+            ->will($this->returnValue($this->manager))
+        ;
+
+        $this->uow = $this->getMockBuilder('Doctrine\ODM\PHPCR\UnitOfWork')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $this->manager->expects($this->any())
+            ->method('getUnitOfWork')
+            ->with()
+            ->will($this->returnValue($this->uow))
+        ;
+
+        $this->extension = new TwigExtension($this->pwc, $this->managerRegistry, 'foo');
+    }
+
+    public function testGetFunctions()
+    {
+        $extension = new TwigExtension($this->pwc);
+        $this->assertCount(1, $extension->getFunctions());
+
+        $this->assertCount(15, $this->extension->getFunctions());
+    }
+
+    public function testGetNodeName()
+    {
+        $document = new \stdClass();
+
+
+        $this->assertEquals(false, $this->extension->getNodeName($document));
+
+        $this->uow->expects($this->once())
+            ->method('getDocumentId')
+            ->with($document)
+            ->will($this->returnValue('/foo/bar'))
+        ;
+
+        $this->assertEquals('bar', $this->extension->getNodeName($document));
+    }
+
+    public function testGetParentPath()
+    {
+        $document = new \stdClass();
+
+        $this->assertEquals(false, $this->extension->getParentPath($document));
+
+        $this->uow->expects($this->once())
+            ->method('getDocumentId')
+            ->with($document)
+            ->will($this->returnValue('/foo/bar'))
+        ;
+
+        $this->assertEquals('/foo', $this->extension->getParentPath($document));
+    }
+
+    public function testGetPath()
+    {
+        $document = new \stdClass();
+
+        $this->assertEquals(null, $this->extension->getPath($document));
+
+        $this->uow->expects($this->once())
+            ->method('getDocumentId')
+            ->with($document)
+            ->will($this->returnValue('/foo/bar'))
+        ;
+
+        $this->assertEquals('/foo/bar', $this->extension->getPath($document));
+    }
+
+    public function testFind()
+    {
+        $document = new \stdClass();
+
+        $this->manager->expects($this->any())
+            ->method('find')
+            ->with(null, '/foo')
+            ->will($this->onConsecutiveCalls(null, $document))
+        ;
+
+        $this->assertNull($this->extension->find('/foo'));
+        $this->assertEquals($document, $this->extension->find('/foo'));
+    }
+
+    public function testFindMany()
+    {
+        $this->assertEquals(array(), $this->extension->findMany());
+    }
+
+    public function testFindManyFilterClass()
+    {
+        $documentA = new \stdClass();
+        $documentB = new \stdClass();
+
+        $this->manager->expects($this->any())
+            ->method('find')
+            ->will($this->onConsecutiveCalls($documentA, null, $documentA, $documentB))
+        ;
+
+        $this->assertEquals(array(), $this->extension->findMany(array('/foo', 'bar'), false, false, null, 'Exception'));
+        $this->assertEquals(array($documentA, $documentB), $this->extension->findMany(array('/foo', 'bar'), false, false, null, 'stdClass'));
+    }
+
+    public function testFindManyIgnoreRole()
+    {
+        $documentA = new \stdClass();
+        $documentB = new \stdClass();
+
+        $this->manager->expects($this->any())
+            ->method('find')
+            ->will($this->onConsecutiveCalls($documentA, null, $documentA, $documentB))
+        ;
+
+        $this->pwc->expects($this->any())
+            ->method('checkIsPublished')
+            ->with($documentA)
+            ->will($this->onConsecutiveCalls(false, true))
+        ;
+
+        $this->assertEquals(array($documentA), $this->extension->findMany(array('/foo', 'bar'), false, false, null));
+        $this->assertEquals(array($documentB), $this->extension->findMany(array('/foo', 'bar'), false, false, false));
+    }
+
+    public function testFindManyLimitOffset()
+    {
+        $documentA = new \stdClass();
+        $documentB = new \stdClass();
+
+        $this->manager->expects($this->any())
+            ->method('find')
+            ->will($this->onConsecutiveCalls($documentA, $documentB, $documentA, $documentB, $documentA, $documentB))
+        ;
+
+        $this->assertEquals(array($documentA), $this->extension->findMany(array('/foo', 'bar'), 1, false, null));
+        $this->assertEquals(array($documentB), $this->extension->findMany(array('/foo', 'bar'), false, 1, null));
+        $this->assertEquals(array($documentB), $this->extension->findMany(array('/foo', 'bar'), 1, 1, null));
+    }
+
+    public function testIsPublished()
+    {
+        $this->assertFalse($this->extension->isPublished(null));
+
+        $document = new \stdClass();
+
+        $this->pwc->expects($this->any())
+            ->method('checkIsPublished')
+            ->with($document)
+            ->will($this->onConsecutiveCalls(false, true))
+        ;
+
+        $this->assertFalse($this->extension->isPublished($document));
+        $this->assertTrue($this->extension->isPublished($document));
+    }
+
+    public function testGetLocalesFor()
+    {
+        $this->assertEquals(array(), $this->extension->getLocalesFor(null));
+
+        $document = new \stdClass();
+
+        $this->manager->expects($this->any())
+            ->method('find')
+            ->with(null, '/foo')
+            ->will($this->onConsecutiveCalls(null, $document))
+        ;
+
+        $this->assertEquals(array(), $this->extension->getLocalesFor('/foo'));
+
+        $this->manager->expects($this->once())
+            ->method('getLocalesFor')
+            ->with($document)
+            ->will($this->returnValue(array('en', 'de')))
+        ;
+
+        $this->assertEquals(array('en', 'de'), $this->extension->getLocalesFor('/foo'));
+    }
+
+    public function testGetLocalesForMissingTranslationException()
+    {
+        $this->markTestIncomplete('TODO: write test');
+    }
+
+    public function testGetChild()
+    {
+        $parent = new \stdClass();
+
+        $this->assertEquals(null, $this->extension->getChild($parent, 'bar'));
+
+        $child = new \stdClass();
+
+        $this->uow->expects($this->once())
+            ->method('getDocumentId')
+            ->with($parent)
+            ->will($this->returnValue('/foo'))
+        ;
+
+        $this->manager->expects($this->once())
+            ->method('find')
+            ->with(null, '/foo/bar')
+            ->will($this->returnValue($child))
+        ;
+
+        $this->assertEquals($child, $this->extension->getChild($parent, 'bar'));
+    }
+
+    public function testGetChildren()
+    {
+        $parent = new \stdClass();
+        $child = new \stdClass();
+
+        $this->manager->expects($this->any())
+            ->method('getChildren')
+            ->with($parent)
+            ->will($this->returnValue(array($child)))
+        ;
+
+        $this->assertEquals(array(), $this->extension->getChildren(null));
+        $this->assertEquals(array(), $this->extension->getChildren($parent, false, false, true));
+    }
+
+    public function testGetChildrenFilterClass()
+    {
+        $this->markTestIncomplete('TODO: write test');
+    }
+
+    public function testGetChildrenIgnoreRole()
+    {
+        $this->markTestIncomplete('TODO: write test');
+    }
+
+    public function testGetChildrenLimitOffset()
+    {
+        $this->markTestIncomplete('TODO: write test');
+    }
+
+    public function testGetLinkableChildren()
+    {
+        $this->assertEquals(array(), $this->extension->getLinkableChildren(null));
+
+        $this->markTestIncomplete('TODO: write test');
+    }
+
+    public function testGetDescendants()
+    {
+        $this->assertEquals(array(), $this->extension->getDescendants(null));
+
+        $this->markTestIncomplete('TODO: write test');
+    }
+
+    public function testGetPrev()
+    {
+        $this->assertNull($this->extension->getPrev(null));
+
+        $this->markTestIncomplete('TODO: write test');
+    }
+
+    public function testGetNext()
+    {
+        $this->assertNull($this->extension->getNext(null));
+
+        $this->markTestIncomplete('TODO: write test');
+    }
+
+    public function testGetPrevLinkable()
+    {
+        $this->assertNull($this->extension->getPrevLinkable(null));
+
+        $this->markTestIncomplete('TODO: write test');
+    }
+
+    public function testGetNextLinkable()
+    {
+        $this->assertNull($this->extension->getNextLinkable(null));
+
+        $this->markTestIncomplete('TODO: write test');
+    }
+}

--- a/Twig/TwigExtension.php
+++ b/Twig/TwigExtension.php
@@ -2,11 +2,11 @@
 
 namespace Symfony\Cmf\Bundle\CoreBundle\Twig;
 
-use PHPCR\Util\PathHelper;
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowCheckerInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\Exception\MissingTranslationException;
 use Doctrine\ODM\PHPCR\DocumentManager;
+use PHPCR\Util\PathHelper;
 
 class TwigExtension extends \Twig_Extension
 {
@@ -36,76 +36,234 @@ class TwigExtension extends \Twig_Extension
         }
     }
 
+    /**
+     * Get list of available functions
+     *
+     * @return array
+     */
     public function getFunctions()
     {
         $functions = array('cmf_is_published' => new \Twig_Function_Method($this, 'isPublished'));
 
         if ($this->dm) {
-            $functions['cmf_child'] = new \Twig_Function_Method($this, 'child');
-            $functions['cmf_children'] = new \Twig_Function_Method($this, 'children');
-            $functions['cmf_prev'] = new \Twig_Function_Method($this, 'prev');
-            $functions['cmf_next'] = new \Twig_Function_Method($this, 'next');
+            $functions['cmf_child'] = new \Twig_Function_Method($this, 'getChild');
+            $functions['cmf_children'] = new \Twig_Function_Method($this, 'getChildren');
+            $functions['cmf_prev'] = new \Twig_Function_Method($this, 'getPrev');
+            $functions['cmf_next'] = new \Twig_Function_Method($this, 'getNext');
             $functions['cmf_find'] = new \Twig_Function_Method($this, 'find');
+            $functions['cmf_find_many'] = new \Twig_Function_Method($this, 'findMany');
+            $functions['cmf_descendants'] = new \Twig_Function_Method($this, 'getDescendants');
             $functions['cmf_nodename'] = new \Twig_Function_Method($this, 'getNodeName');
             $functions['cmf_parent_path'] = new \Twig_Function_Method($this, 'getParentPath');
             $functions['cmf_path'] = new \Twig_Function_Method($this, 'getPath');
             $functions['cmf_document_locales'] = new \Twig_Function_Method($this, 'getLocalesFor');
 
             if (interface_exists('Symfony\Cmf\Component\Routing\RouteAwareInterface')) {
-                $functions['cmf_prev_linkable'] = new \Twig_Function_Method($this, 'prevLinkable');
-                $functions['cmf_next_linkable'] = new \Twig_Function_Method($this, 'nextLinkable');
-                $functions['cmf_children_linkable'] = new \Twig_Function_Method($this, 'childrenLinkable');
+                $functions['cmf_prev_linkable'] = new \Twig_Function_Method($this, 'getPrevLinkable');
+                $functions['cmf_next_linkable'] = new \Twig_Function_Method($this, 'getNextLinkable');
+                $functions['cmf_linkable_children'] = new \Twig_Function_Method($this, 'getLinkableChildren');
             }
         }
 
         return $functions;
     }
 
+    /**
+     * Get the extension name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'cmf_extension';
+    }
+
+    /**
+     * @param object $document
+     * @return boolean|string node name or false if the document is not in the unit of work
+     */
     public function getNodeName($document)
     {
         return PathHelper::getNodeName($this->getPath($document));
     }
 
+    /**
+     * @param object $document
+     * @return boolean|string node name or false if the document is not in the unit of work
+     */
     public function getParentPath($document)
     {
         return PathHelper::getParentPath($this->getPath($document));
     }
 
+    /**
+     * @param object $document
+     * @return boolean|string path or false if the document is not in the unit of work
+     */
     public function getPath($document)
     {
-        return $this->dm->getUnitOfWork()->getDocumentId($document);
-    }
-
-    public function child($parent, $name)
-    {
-        $parentId = $this->dm->getUnitOfWork()->getDocumentId($parent);
-        return $this->dm->find(null, $parentId.'/'.$name);
-    }
-
-    public function childrenLinkable($parent, $limit = false, $ignoreRole = false, $filter = null)
-    {
-        return $this->children($parent, $limit, $ignoreRole, $filter, 'Symfony\Cmf\Component\Routing\RouteAwareInterface');
+        try {
+            return $this->dm->getUnitOfWork()->getDocumentId($document);
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     /**
-     * @param object $parent parent document
-     * @param int|bool $limit int limit or false
-     * @param string|bool $offset string node name to which to skip to or false
-     * @param bool|null $ignoreRole boolean if the role should be ignored or null if publish workflow should be ignored
-     * @param string|null $filter child filter
-     * @param string|null $class class name to filter on
+     * Find a document by path
+     *
+     * @param $path
+     * @return null|object
+     */
+    public function find($path)
+    {
+        return $this->dm->find(null, $path);
+    }
+
+    /**
+     * Get a document instance and validate if its eligible
+     *
+     * @param string|object $document
+     * @param Boolean|null $ignoreRole if the role should be ignored or null if publish workflow should be ignored
+     * @param null|string $class class name to filter on
+     * @return null|object
+     */
+    private function getDocument($document, $ignoreRole = false, $class = null)
+    {
+        if (is_string($document)) {
+            $document = $this->dm->find(null, $document);
+        }
+
+        if (empty($document)
+            || (null !== $ignoreRole && !$this->publishWorkflowChecker->checkIsPublished($document, $ignoreRole))
+            || (null != $class && !($document instanceof $class))
+        ) {
+            return null;
+        }
+
+        return $document;
+    }
+
+    /**
+     * @param array $paths list of paths
+     * @param int|Boolean $limit int limit or false
+     * @param string|Boolean $offset string node name to which to skip to or false
+     * @param Boolean|null $ignoreRole if the role should be ignored or null if publish workflow should be ignored
+     * @param null|string $class class name to filter on
      * @return array
      */
-    public function children($parent, $limit = false, $offset = false, $ignoreRole = false, $filter = null, $class = null)
+    public function findMany($paths = array(), $limit = false, $offset = false, $ignoreRole = false, $class = null)
+    {
+        if ($offset) {
+            $paths = array_slice($paths, $offset);
+        }
+
+        $result = array();
+        foreach ($paths as $path) {
+            $document = $this->getDocument($path, $ignoreRole, $class);
+            if (null === $document) {
+                continue;
+            }
+
+            $result[] = $document;
+            if (false !== $limit) {
+                $limit--;
+                if (!$limit) {
+                    break;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if a document is published
+     *
+     * @param $document
+     * @return Boolean
+     */
+    public function isPublished($document)
+    {
+        if (empty($document)) {
+            return false;
+        }
+
+        return $this->publishWorkflowChecker->checkIsPublished($document, true);
+    }
+
+    /**
+     * Get the locales of the document
+     *
+     * @param string|object $document document instance or path
+     * @param Boolean $includeFallbacks
+     * @return array
+     */
+    public function getLocalesFor($document, $includeFallbacks = false)
+    {
+        if (is_string($document)) {
+            $document = $this->dm->find(null, $document);
+        }
+
+        if (empty($document)) {
+            return array();
+        }
+
+        try {
+            $locales = $this->dm->getLocalesFor($document, $includeFallbacks);
+        } catch (MissingTranslationException $e) {
+            $locales = array();
+        }
+
+        return $locales;
+    }
+
+    /**
+     * @param string|object $parent parent path/document
+     * @param string $name
+     * @return boolean|null|object child or null if the child cannot be found or false if the parent is not in the unit of work
+     */
+    public function getChild($parent, $name)
+    {
+        if (is_object($parent)) {
+            try {
+                $parent = $this->dm->getUnitOfWork()->getDocumentId($parent);
+            } catch (\Exception $e) {
+                return false;
+            }
+        }
+
+        return $this->dm->find(null, "$parent/$name");
+    }
+
+    /**
+     * Get child documents
+     *
+     * @param string|object $parent parent path/document
+     * @param int|Boolean $limit int limit or false
+     * @param string|Boolean $offset string node name to which to skip to or false
+     * @param null|string $filter child filter
+     * @param Boolean|null $ignoreRole if the role should be ignored or null if publish workflow should be ignored
+     * @param null|string $class class name to filter on
+     * @return array
+     */
+    public function getChildren($parent, $limit = false, $offset = false, $filter = null, $ignoreRole = false, $class = null)
     {
         if (empty($parent)) {
             return array();
         }
 
         if ($limit || $offset) {
-            $parentId = $this->dm->getUnitOfWork()->getDocumentId($parent);
-            $node = $this->dm->getPhpcrSession()->getNode($parentId);
+            if (is_object($parent)) {
+                $parent = $this->dm->getUnitOfWork()->getDocumentId($parent);
+            }
+            $node = $this->dm->getPhpcrSession()->getNode($parent);
             $children = (array) $node->getNodeNames();
+            foreach ($children as $key => $child) {
+                if (strpos($child, 'phpcr_locale:') === 0) {
+                    unset($children[$key]);
+                }
+            }
             if ($offset) {
                 $key = array_search($offset, $children);
                 if (false === $key) {
@@ -118,14 +276,13 @@ class TwigExtension extends \Twig_Extension
         }
 
         $result = array();
-        foreach ($children as $child) {
-            if ($limit !== false || $offset !== false) {
-                $child = $this->dm->find(null, "$parentId/$child");
+        foreach ($children as $name => $child) {
+            if (strpos($name, 'phpcr_locale:') === 0) {
+                continue;
             }
 
-            if (null === $ignoreRole || !$this->publishWorkflowChecker->checkIsPublished($child, $ignoreRole)
-                || (null != $class && !($child instanceof $class))
-            ) {
+            $child = $this->getDocument($child, $ignoreRole, $class);
+            if (null === $child) {
                 continue;
             }
 
@@ -141,36 +298,101 @@ class TwigExtension extends \Twig_Extension
         return $result;
     }
 
-    private function search($current, $reverse = false, $class = null)
+    /**
+     * Get linkable child documents
+     *
+     * @param string|object $parent parent path/document
+     * @param int|Boolean $limit int limit or false
+     * @param string|Boolean $offset string node name to which to skip to or false
+     * @param null|string $filter child filter
+     * @param Boolean|null $ignoreRole if the role should be ignored or null if publish workflow should be ignored
+     * @return array
+     */
+    public function getLinkableChildren($parent, $limit = false, $offset = false, $filter = null, $ignoreRole = false)
     {
-        if (empty($current)) {
-            return null;
+        return $this->getChildren($parent, $limit, $offset, $filter, $ignoreRole, 'Symfony\Cmf\Component\Routing\RouteAwareInterface');
+    }
+
+    /**
+     * Get the paths of children
+     *
+     * @param string $path
+     * @param array $children
+     * @param integer $depth
+     */
+    private function getChildrenPaths($path, array &$children, $depth)
+    {
+        if (null !== $depth && $depth < 1) {
+            return;
         }
 
-        $path = $this->dm->getUnitOfWork()->getDocumentId($current);
+        --$depth;
+
         $node = $this->dm->getPhpcrSession()->getNode($path);
-        $parent = $node->getParent();
-        $childNames = $parent->getNodeNames();
+        $names = (array) $node->getNodeNames();
+        foreach ($names as $name) {
+            if (strpos($name, 'phpcr_locale:') === 0) {
+                continue;
+            }
+
+            $children[] = $child = "$path/$name";
+            $this->getChildrenPaths($child, $children, $depth);
+        }
+    }
+
+    /**
+     * @param string|object $parent parent path/document
+     * @param null|int $depth null denotes no limit, depth of 1 means direct children only etc.
+     * @return array
+     */
+    public function getDescendants($parent, $depth = null)
+    {
+        if (empty($parent)) {
+            return array();
+        }
+
+        $children = array();
+        if (is_object($parent)) {
+            $parent = $this->dm->getUnitOfWork()->getDocumentId($parent);
+        }
+        $this->getChildrenPaths($parent, $children, $depth);
+
+        return $children;
+    }
+
+    /**
+     * Check children for a possible following document
+     *
+     * @param \Traversable $childNames
+     * @param Boolean $reverse
+     * @param string $parentPath
+     * @param Boolean $ignoreRole
+     * @param null|string $class
+     * @param null|string $nodeName
+     * @return null|object
+     */
+    private function checkChildren($childNames, $reverse, $parentPath, $ignoreRole = false, $class = null, $nodeName = null)
+    {
         if ($reverse) {
             $childNames = array_reverse($childNames->getArrayCopy());
         }
 
-        $check = false;
+        $check = empty($nodeName);
         foreach ($childNames as $name) {
+            if (strpos($name, 'phpcr_locale:') === 0) {
+                continue;
+            }
+
             if ($check) {
                 try {
-                    $child = $this->dm->find(null, $parent->getPath().'/'.$name);
-                    if ($this->publishWorkflowChecker->checkIsPublished($child)
-                        && (null === $class || $child instanceof $class)
-                    ) {
+                    $child = $this->getDocument("$parentPath/$name", $ignoreRole, $class);
+                    if ($child) {
                         return $child;
                     }
                 } catch (MissingTranslationException $e) {
                     continue;
                 }
-            }
-
-            if ($node->getName() == $name) {
+            } elseif ($nodeName == $name) {
                 $check = true;
             }
         }
@@ -178,57 +400,127 @@ class TwigExtension extends \Twig_Extension
         return null;
     }
 
-    public function prev($current)
+    /**
+     * Search for a following document
+     *
+     * @param string|object $path document instance or path
+     * @param string|object $anchor document instance or path
+     * @param null|integer $depth
+     * @param Boolean $reverse
+     * @param Boolean $ignoreRole
+     * @param null|string $class
+     * @return null|object
+     */
+    private function search($path, $anchor = null, $depth = null, $reverse = false, $ignoreRole = false, $class = null)
     {
-        return $this->search($current, true);
-    }
-
-    public function next($current)
-    {
-        return $this->search($current);
-    }
-
-    public function prevLinkable($current)
-    {
-        return $this->search($current, true, 'Symfony\Cmf\Component\Routing\RouteAwareInterface');
-    }
-
-    public function nextLinkable($current)
-    {
-        return $this->search($current, false, 'Symfony\Cmf\Component\Routing\RouteAwareInterface');
-    }
-
-    public function isPublished($document)
-    {
-        if (empty($document)) {
-            return false;
+        if (empty($path)) {
+            return null;
         }
 
-        return $this->publishWorkflowChecker->checkIsPublished($document, true);
-    }
+        if (is_object($path)) {
+            $path = $this->dm->getUnitOfWork()->getDocumentId($path);
+        }
 
-    public function find($path)
-    {
-        return $this->dm->find(null, $path);
-    }
+        $node = $this->dm->getPhpcrSession()->getNode($path);
 
-    public function getLocalesFor($document, $includeFallbacks = false)
-    {
-        try {
-            if (empty($document)) {
-                return array();
+        if ($anchor) {
+            if (is_object($anchor)) {
+                $anchor = $this->dm->getUnitOfWork()->getDocumentId($anchor);
             }
 
-            $locales = $this->dm->getLocalesFor($document, $includeFallbacks);
-        } catch (MissingTranslationException $e) {
-            $locales = array();
+            if (strpos($path, $anchor) !== 0) {
+                throw new \RuntimeException("The anchor path '$anchor' is not a parent of the current path '$path'.");
+            }
+
+            if (!$reverse
+                && (null === $depth || PathHelper::getPathDepth($path() - PathHelper::getPathDepth($anchor)) < $depth)
+            ) {
+                $childNames = $node->getNodeNames();
+
+                if ($childNames->count()) {
+                    $result = $this-> checkChildren($childNames, $reverse, $path, $ignoreRole, $class);
+                    if ($result) {
+                        return $result;
+                    }
+                }
+            }
         }
 
-        return $locales;
+        $nodename = $node->getName();
+
+        do {
+            $parentNode = $node->getParent();
+            $childNames = $parentNode->getNodeNames();
+            $result = $this->checkChildren($childNames, $reverse, $parentNode->getPath(), $ignoreRole, $class, $nodename);
+            if ($result || !$anchor) {
+                return $result;
+            }
+
+            $node = $parentNode;
+            if ($nodename) {
+                $reverse = !$reverse;
+                $nodename = null;
+            }
+        } while (!$anchor || $anchor !== $node->getPath());
+
+        return null;
     }
 
-    public function getName()
+    /**
+     * Get the previous document
+     *
+     * @param string|object $current document instance or path
+     * @param string|object $parent document instance or path
+     * @param null|integer $depth
+     * @param Boolean $ignoreRole
+     * @param null|string $class
+     * @return null|object
+     */
+    public function getPrev($current, $parent = null, $depth = null, $ignoreRole = false, $class = null)
     {
-        return 'children_extension';
+        return $this->search($current, $parent, $depth, true, $ignoreRole, $class);
+    }
+
+    /**
+     * Get the next document
+     *
+     * @param string|object $current document instance or path
+     * @param string|object $parent document instance or path
+     * @param null|integer $depth
+     * @param Boolean $ignoreRole
+     * @param null|string $class
+     * @return null|object
+     */
+    public function getNext($current, $parent = null, $depth = null, $ignoreRole = false, $class = null)
+    {
+        return $this->search($current, $parent, $depth, false, $ignoreRole, $class);
+    }
+
+    /**
+     * Get the previous linkable document
+     *
+     * @param string|object $current document instance or path
+     * @param string|object $parent document instance or path
+     * @param null|integer $depth
+     * @param Boolean $ignoreRole
+     * @return null|object
+     */
+    public function getPrevLinkable($current, $parent = null, $depth = null, $ignoreRole = false)
+    {
+        return $this->search($current, $parent, $depth, true, $ignoreRole, 'Symfony\Cmf\Component\Routing\RouteAwareInterface');
+    }
+
+    /**
+     * Get the next linkable document
+     *
+     * @param string|object $current document instance or path
+     * @param string|object $parent document instance or path
+     * @param null|integer $depth
+     * @param Boolean $ignoreRole
+     * @return null|object
+     */
+    public function getNextLinkable($current, $parent = null, $depth = null, $ignoreRole = false)
+    {
+        return $this->search($current, $parent, $depth, false, $ignoreRole, 'Symfony\Cmf\Component\Routing\RouteAwareInterface');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,16 @@
             "homepage": "https://github.com/symfony-cmf/CoreBundle/contributors"
         }
     ],
+    "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": ">=2.1,<2.3-dev"
     },
     "require-dev": {
+        "symfony-cmf/routing": "~1.1-dev",
+        "doctrine/phpcr-bundle": "1.0.*",
+        "doctrine/phpcr-odm": "1.0.*",
+        "twig/twig": "~1.11",
         "symfony/security-bundle": ">=2.1,<2.3-dev"
     },
     "suggest": {


### PR DESCRIPTION
fixes #10 and #11
this PR also makes it possible to pass in a path instead of a document in most places

there really should be some unit tests for the prev/next stuff at the very least

```
{% set foo = '/cms/content/home/additionalInfoBlock' %}
current: {{ foo }}<br />
prev: {{ cmf_path(cmf_prev(foo, '/cms', 4)) }}<br />
next: {{ cmf_path(cmf_next(foo, '/cms', 4)) }}<br />
<br />
{% set foo = '/cms/content/home/additionalInfoBlock/child1' %}
current: {{ foo }}<br />
prev: {{ cmf_path(cmf_prev(foo, '/cms', 4)) }}<br />
next: {{ cmf_path(cmf_next(foo, '/cms', 4)) }}<br />
<br />
{% set foo = '/cms/content/home/additionalInfoBlock/child2' %}
current: {{ foo }}<br />
prev: {{ cmf_path(cmf_prev(foo, '/cms', 4)) }}<br />
next: {{ cmf_path(cmf_next(foo, '/cms', 4)) }}<br />
<br />
{% set foo = '/cms/content/home/additionalInfoBlock/child3' %}
current: {{ foo }}<br />
prev: {{ cmf_path(cmf_prev(foo, '/cms', 4)) }}<br />
next: {{ cmf_path(cmf_next(foo, '/cms', 4)) }}<br />
<br />
```
