### PR TITLE
Improve xml

### DIFF
--- a/DependencyInjection/SymfonyCmfCoreExtension.php
+++ b/DependencyInjection/SymfonyCmfCoreExtension.php
@@ -27,6 +27,16 @@ class SymfonyCmfCoreExtension extends Extension
         }
     }
 
+    /**
+     * Returns the base path for the XSD files.
+     *
+     * @return string The XSD base path
+     */
+    public function getXsdValidationBasePath()
+    {
+        return __DIR__.'/../Resources/config/schema';
+    }
+
     public function getNamespace()
     {
         return 'http://cmf.symfony.com/schema/dic/core';

--- a/Resources/config/schema/core-1.0.xsd
+++ b/Resources/config/schema/core-1.0.xsd
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<xsd:schema xmlns="http://cmf.symfony.com/schema/dic/core"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://cmf.symfony.com/schema/dic/core"
+    elementFormDefault="qualified">
+
+    <xsd:element name="config" type="config" />
+
+    <xsd:complexType name="config">
+        <xsd:attribute name="document-manager-name" type="xsd:string" />
+        <xsd:attribute name="role" type="xsd:string" />
+        <xsd:attribute name="publish-workflow-listener" type="boolean" />
+    </xsd:complexType>
+    
+    <xsd:simpleType name="boolean">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="true" />
+            <xsd:enumeration value="false" />
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>


### PR DESCRIPTION
One thing I like to discuss is the namespace here. From what I read, this bundle is the base bundle which combines the cmf bundles into a usable cmf. That means it's somewhat equal to the FrameworkBundle in sf2.

If that's the case, we should have a namespace ending with `cmf` instead of `core`. (and the xsd file should also be renamed).
