### PR TITLE
only set the master request on request_aware services

### DIFF
--- a/EventListener/RequestAwareListener.php
+++ b/EventListener/RequestAwareListener.php
@@ -23,6 +23,10 @@ class RequestAwareListener implements EventSubscriberInterface
 
     public function onKernelRequest(GetResponseEvent $event)
     {
+        if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
+            return;
+        }
+
         foreach ($this->services as $service) {
             $service->setRequest($event->getRequest());
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | not sure |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

i had problems that my current menu item voter did not see the main request but got it overwritten with some subrequest. i found some code in the [locale bundle](https://github.com/lunetics/LocaleBundle/blob/master/EventListener/LocaleListener.php#L93) - not 100% sure if this is all sane.
