### PR TITLE
use symfony 2.3 synchronized services for cmf_request_aware and emulate in symfony 2.2

### DIFF
--- a/DependencyInjection/Compiler/RequestAwarePass.php
+++ b/DependencyInjection/Compiler/RequestAwarePass.php
@@ -2,8 +2,10 @@
 
 namespace Symfony\Cmf\Bundle\CoreBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 
 /**
@@ -21,6 +23,14 @@ class RequestAwarePass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        if (version_compare(Kernel::VERSION, '2.3', '<')) {
+            $this->configureSynchronizer($container);
+        } else {
+            $this->makeSynchronized($container);
+        }
+    }
+    private function configureSynchronizer(ContainerBuilder $container)
+    {
         if (!$container->hasDefinition('cmf_core.listener.request_aware')) {
             return;
         }
@@ -29,6 +39,20 @@ class RequestAwarePass implements CompilerPassInterface
         $services = $container->findTaggedServiceIds('cmf_request_aware');
         foreach ($services as $id => $attributes) {
             $listener->addMethodCall('addService', array(new Reference($id)));
+        }
+    }
+
+    private function makeSynchronized(ContainerBuilder $container)
+    {
+        $services = $container->findTaggedServiceIds('cmf_request_aware');
+        foreach ($services as $id => $attributes) {
+            $definition = $container->getDefinition($id);
+            $definition
+                ->setSynchronized(true)
+                ->addMethodCall('setRequest', array(
+                    new Reference('request', ContainerInterface::NULL_ON_INVALID_REFERENCE, false)
+                ))
+            ;
         }
     }
 }

--- a/EventListener/RequestAwareListener.php
+++ b/EventListener/RequestAwareListener.php
@@ -5,26 +5,41 @@ namespace Symfony\Cmf\Bundle\CoreBundle\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-use Symfony\Cmf\Bundle\MenuBundle\Voter\VoterInterface;
-
 /**
- * Set the master request on services tagged with cmf_request_aware
+ * Set and update the request on services tagged with cmf_request_aware
+ *
+ * This listener is emulating the Symfony 2.3 synchronized service behaviour
+ * in Symfony 2.2.
  *
  * The objects must have a method setRequest that accepts a Request as
- * parameter. If they don't, the problem is silently ignored.
+ * parameter. Note that the request may also be null, after the master
+ * request is terminated
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
 class RequestAwareListener implements EventSubscriberInterface
 {
-    protected $services = array();
+    private $services = array();
+    private $requestStack = array();
 
     public function onKernelRequest(GetResponseEvent $event)
     {
+        $request = $event->getRequest();
+        array_push($this->requestStack, $request);
         foreach ($this->services as $service) {
-            $service->setRequest($event->getRequest());
+            $service->setRequest($request);
+        }
+    }
+
+    public function onKernelTerminate(PostResponseEvent $event)
+    {
+        array_pop($this->requestStack);
+        $request = empty($this->requestStack) ? null : end($this->requestStack);
+        foreach ($this->services as $service) {
+            $service->setRequest($request);
         }
     }
 
@@ -42,6 +57,7 @@ class RequestAwareListener implements EventSubscriberInterface
     {
         return array(
             KernelEvents::REQUEST => 'onKernelRequest',
+            KernelEvents::TERMINATE => 'onKernelTerminate',
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | sort of |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | n/a |
| Fixed tickets | - |
| License | MIT |
| Doc PR | TODO |

The rationale for this is to have bundles that support both symfony 2.2 and 2.3. If we agree that this is sane to do, i will update the doc. It would be very nice to also test this - having the testing component bootstrapped in CoreBundle would help a lot.
