### PR TITLE
always have a publish workflow service even when workflow is disabled

### DIFF
--- a/DependencyInjection/CmfCoreExtension.php
+++ b/DependencyInjection/CmfCoreExtension.php
@@ -20,11 +20,24 @@ class CmfCoreExtension extends Extension
         $container->setParameter($this->getAlias() . '.document_manager_name', $config['document_manager_name']);
 
         if ($config['publish_workflow']['enabled']) {
-            $this->loadPublishWorkflow($config['publish_workflow'], $loader, $container);
+            $checker = $this->loadPublishWorkflow($config['publish_workflow'], $loader, $container);
+        } else {
+            $loader->load('no_publish_workflow.xml');
+            $checker = 'cmf_core.publish_workflow.checker.always';
         }
+        $container->setAlias('cmf_core.publish_workflow.checker', $checker);
     }
 
-    public function loadPublishWorkflow($config, XmlFileLoader $loader, ContainerBuilder $container)
+    /**
+     * @param $config
+     * @param XmlFileLoader $loader
+     * @param ContainerBuilder $container
+     *
+     * @return string the name of the workflow checker service to alias
+     *
+     * @throws InvalidConfigurationException
+     */
+    private function loadPublishWorkflow($config, XmlFileLoader $loader, ContainerBuilder $container)
     {
         $container->setParameter($this->getAlias().'.publish_workflow.view_non_published_role', $config['view_non_published_role']);
         $loader->load('publish_workflow.xml');
@@ -39,6 +52,8 @@ class CmfCoreExtension extends Extension
             $container->removeDefinition($this->getAlias() . '.admin_extension.publish_workflow.publishable');
             $container->removeDefinition($this->getAlias() . '.admin_extension.publish_workflow.time_period');
         }
+
+        return $config['checker_service'];
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('enabled')->defaultTrue()->end()
+                        ->scalarNode('checker_service')->defaultValue('cmf_core.publish_workflow.checker.default')->end()
                         ->scalarNode('view_non_published_role')->defaultValue('ROLE_CAN_VIEW_NON_PUBLISHED')->end()
                         ->booleanNode('request_listener')->defaultTrue()->end()
                     ->end()

--- a/PublishWorkflow/AlwaysPublishedWorkflowChecker.php
+++ b/PublishWorkflow/AlwaysPublishedWorkflowChecker.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+
+/**
+ * A placeholder service to provide instead of the normal publish workflow
+ * checker in case the publish workflow is deactivated in the configuration.
+ *
+ * Services should never accept null as publish workflow checker for security
+ * reasons. Typos or service renames could otherwise lead to severe security
+ * issues.
+ *
+ * @author David Buchmann <mail@davidbu.ch>
+*/
+class AlwaysPublishedWorkflowChecker implements SecurityContextInterface
+{
+    /**
+     * @return null always return null
+     */
+    public function getToken()
+    {
+        return null;
+    }
+
+    /**
+     * Ignored
+     */
+    public function setToken(TokenInterface $token = null)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isGranted($attributes, $object = null)
+    {
+        return true;
+    }
+}

--- a/Resources/config/no_publish_workflow.xml
+++ b/Resources/config/no_publish_workflow.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="cmf_core.publish_workflow.checker_class">Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\AlwaysPublishedWorkflowChecker</parameter>
+    </parameters>
+
+    <services>
+
+        <service id="cmf_core.publish_workflow.checker.always" class="%cmf_core.publish_workflow.checker_class%"/>
+
+    </services>
+</container>

--- a/Resources/config/publish_workflow.xml
+++ b/Resources/config/publish_workflow.xml
@@ -23,7 +23,7 @@
             <argument>true</argument>
         </service>
 
-        <service id="cmf_core.publish_workflow.checker" class="%cmf_core.publish_workflow.checker_class%">
+        <service id="cmf_core.publish_workflow.checker.default" class="%cmf_core.publish_workflow.checker_class%">
             <argument type="service" id="service_container"/>
             <argument type="service" id="cmf_core.publish_workflow.access_decision_manager"/>
             <argument>%cmf_core.publish_workflow.view_non_published_role%</argument>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | TODO |

**security improvement**

this allows services that depend on the publish workflow checker to simplify their logic and avoids security issues by not using `on-invalid="ignore"` service arguments that risk typos.

this is inspired by a discussion with @lapistano about not having every service know about special situations.
