### PR TITLE
fix publish workflow interface usage

### DIFF
--- a/Admin/Extension/PublishTimePeriodExtension.php
+++ b/Admin/Extension/PublishTimePeriodExtension.php
@@ -6,7 +6,8 @@ use Sonata\AdminBundle\Admin\AdminExtension;
 use Sonata\AdminBundle\Form\FormMapper;
 
 /**
- * Admin extension to add publish workflow time period fields.
+ * Admin extension to add publish workflow time period fields for models
+ * implementing PublishTimePeriodInterface.
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */

--- a/Admin/Extension/PublishableExtension.php
+++ b/Admin/Extension/PublishableExtension.php
@@ -6,7 +6,8 @@ use Sonata\AdminBundle\Admin\AdminExtension;
 use Sonata\AdminBundle\Form\FormMapper;
 
 /**
- * Admin extension to add publish workflow publishable field.
+ * Admin extension to add a publish workflow publishable field for models
+ * implementing PublishableInterface.
  *
  * @author Daniel Leech <daniel@dantleech.com>
  */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ Changelog
   using the isGranted method of the standard security will check for
   publication.
   The PublishWorkflowInterface is split into the reading interfaces
-  PublishableInterface and PublishTimePeriodInterface as well as
-  PublishableWriteInterface and PublishableTimePeriodWriteInterface. The sonata
+  PublishableReadInterface and PublishTimePeriodReadInterface as well as
+  PublishableInterface and PublishableTimePeriodInterface. The sonata
   admin extension has been split accordingly and there are now
   cmf_core.admin_extension.publish_workflow.time_period and
   cmf_core.admin_extension.publish_workflow.publishable.

--- a/PublishWorkflow/Voter/PublishTimePeriodVoter.php
+++ b/PublishWorkflow/Voter/PublishTimePeriodVoter.php
@@ -6,10 +6,10 @@ use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodReadInterface;
 
 /**
- * Workflow voter for the PublishTimePeriodInterface.
+ * Workflow voter for the PublishTimePeriodReadInterface.
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
@@ -52,13 +52,13 @@ class PublishTimePeriodVoter implements VoterInterface
      */
     public function supportsClass($class)
     {
-        return is_subclass_of($class, 'Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodInterface');
+        return is_subclass_of($class, 'Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodReadInterface');
     }
 
     /**
      * {@inheritdoc}
      *
-     * @param PublishTimePeriodInterface $object
+     * @param PublishTimePeriodReadInterface $object
      */
     public function vote(TokenInterface $token, $object, array $attributes)
     {

--- a/PublishWorkflow/Voter/PublishableVoter.php
+++ b/PublishWorkflow/Voter/PublishableVoter.php
@@ -6,10 +6,10 @@ use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface;
 
 /**
- * Workflow voter for the PublishableInterface.
+ * Workflow voter for the PublishableReadInterface.
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
@@ -30,13 +30,13 @@ class PublishableVoter implements VoterInterface
      */
     public function supportsClass($class)
     {
-        return is_subclass_of($class, 'Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableInterface');
+        return is_subclass_of($class, 'Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface');
     }
 
     /**
      * {@inheritdoc}
      *
-     * @param PublishableInterface $object
+     * @param PublishableReadInterface $object
      */
     public function vote(TokenInterface $token, $object, array $attributes)
     {

--- a/Tests/Functional/PublishWorkflow/PublishWorkflowTest.php
+++ b/Tests/Functional/PublishWorkflow/PublishWorkflowTest.php
@@ -2,8 +2,8 @@
 
 namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Functional\PublishWorkflow;
 
-use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableInterface;
-use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodReadInterface;
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
 use Symfony\Cmf\Bundle\CoreBundle\Twig\Extension\CmfExtension;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -32,7 +32,7 @@ class PublishWorkflowTest extends BaseTestCase
 
     public function testPublishable()
     {
-        $doc = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableInterface');
+        $doc = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface');
         $doc->expects($this->any())
             ->method('isPublishable')
             ->will($this->returnValue(true))
@@ -96,4 +96,4 @@ class PublishWorkflowTest extends BaseTestCase
     }
 }
 
-abstract class PublishModel implements PublishableInterface, PublishTimePeriodInterface {}
+abstract class PublishModel implements PublishableReadInterface, PublishTimePeriodReadInterface {}

--- a/Tests/Unit/PublishWorkflow/PublishWorkflowCheckerTest.php
+++ b/Tests/Unit/PublishWorkflow/PublishWorkflowCheckerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Unit\PublishWorkflow;
 
-use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableWriteInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface;
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
@@ -32,7 +32,7 @@ class PublishWorkflowCheckerTest extends \PHPUnit_Framework_Testcase
     private $sc;
 
     /**
-     * @var PublishableWriteInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var PublishableReadInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $doc;
 
@@ -52,7 +52,7 @@ class PublishWorkflowCheckerTest extends \PHPUnit_Framework_Testcase
             ->with('security.context')
             ->will($this->returnValue($this->sc))
         ;
-        $this->doc = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableWriteInterface');
+        $this->doc = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface');
         $this->adm = $this->getMock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface');
         $this->stdClass = new \stdClass;
 

--- a/Tests/Unit/PublishWorkflow/Voter/PublishTimePeriodVoterTest.php
+++ b/Tests/Unit/PublishWorkflow/Voter/PublishTimePeriodVoterTest.php
@@ -95,7 +95,7 @@ class PublishTimePeriodVoterTest extends \PHPUnit_Framework_Testcase
     public function testPublishWorkflowChecker($expected, $startDate, $endDate, $attributes = PublishWorkflowChecker::VIEW_ATTRIBUTE, $currentTime = false)
     {
         $attributes = (array) $attributes;
-        $doc = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodInterface');
+        $doc = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodReadInterface');
 
         $doc->expects($this->any())
             ->method('getPublishStartDate')

--- a/Tests/Unit/PublishWorkflow/Voter/PublishableVoterTest.php
+++ b/Tests/Unit/PublishWorkflow/Voter/PublishableVoterTest.php
@@ -73,7 +73,7 @@ class PublishableTest extends \PHPUnit_Framework_Testcase
     public function testPublishWorkflowChecker($expected, $isPublishable, $attributes)
     {
         $attributes = (array) $attributes;
-        $doc = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableInterface');
+        $doc = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface');
         $doc->expects($this->any())
             ->method('isPublishable')
             ->will($this->returnValue($isPublishable))


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | not really |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

the interface users where not adjusted in #82, making the publish workflow voters only vote on writeable models, which makes no sense. tests also where not adjusted.
