### PR TITLE
Fixed Single-Language

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,6 +9,8 @@
         <parameter key="cmf_core.twig_extension.class">Symfony\Cmf\Bundle\CoreBundle\Twig\Extension\CmfExtension</parameter>
         <parameter key="cmf_core.templating.helper.class">Symfony\Cmf\Bundle\CoreBundle\Templating\Helper\CmfHelper</parameter>
         <parameter key="cmf_core.listener.request_aware.class">Symfony\Cmf\Bundle\CoreBundle\EventListener\RequestAwareListener</parameter>
+
+        <parameter key="cmf_core.multilang.locales" type="collection"></parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

When multilanguage is disabled, so no locales are set in `cmf_core.multilang`, the DIC parameter `cmf_core.multilang.locales` did not exists. The [SimpleCMS's Phpcr RouteProvider is depending on this parameter](https://github.com/symfony-cmf/SimpleCmsBundle/blob/master/Resources/config/routing-phpcr.xml#L28), so it resulted in an error.

Setting a default empty array in the configuration solved this bug.
