### PR TITLE
blockbundle dropped the content_basepath configuration

### DIFF
--- a/DependencyInjection/CmfCoreExtension.php
+++ b/DependencyInjection/CmfCoreExtension.php
@@ -46,7 +46,6 @@ class CmfCoreExtension extends Extension implements PrependExtensionInterface
                                 'phpcr' => array(
                                     'enabled' => $persistenceConfig['enabled'],
                                     'use_sonata_admin' => $persistenceConfig['use_sonata_admin'],
-                                    'content_basepath' => $persistenceConfig['basepath'].'/content',
                                     'block_basepath' => $persistenceConfig['basepath'].'/content',
                                     'manager_name' => $persistenceConfig['manager_name'],
                                 )


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | adjust to https://github.com/symfony-cmf/BlockBundle/pull/131 |
| License | MIT |

This needs to be merged right before tagging the next release.
