### PR TITLE
only prepend an image path to CreateBundle if MediaBundle is not present

### DIFF
--- a/DependencyInjection/CmfCoreExtension.php
+++ b/DependencyInjection/CmfCoreExtension.php
@@ -73,12 +73,16 @@ class CmfCoreExtension extends Extension implements PrependExtensionInterface
                             'persistence' => array(
                                 'phpcr' => array(
                                     'enabled' => $persistenceConfig['enabled'],
-                                    'image' => array(
-                                        'basepath' => $persistenceConfig['basepath'].'/media',
-                                    )
                                 )
                             )
                         );
+                        // if cmf_media is there, it will prepend the image path to its media_basepath
+                        // setting.
+                        if (!isset($extensions['cmf_media'])) {
+                            $prependConfig['persistence']['phpcr']['image'] = array(
+                                'basepath' => $persistenceConfig['basepath'].'/media',
+                            );
+                        }
                         break;
                     case 'cmf_media':
                         $prependConfig = array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

as per discussion in https://github.com/symfony-cmf/MediaBundle/issues/36#issuecomment-23643093
