### PR TITLE
[POC] Added default trans strategy parameter

### DIFF
--- a/Resources/config/translatable.xml
+++ b/Resources/config/translatable.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="cmf_core.admin_extension.translatable.class">Symfony\Cmf\Bundle\CoreBundle\Admin\Extension\TranslatableExtension</parameter>
+        <parameter key="cmf_core.persistence.phpcr.translation_strategy" />
     </parameters>
 
     <services>


### PR DESCRIPTION
I was getting parameter not existing exception

```
The service "cmf_core.persistence.phpcr.translatable_metadata_listener" has a dependency on a non-existent parameter "cmf_core.persistence.phpcr.translation_strategy". Did you mean this: "cmf_core.persistence.phpcr.manager_name"?
```

When executing tests for MenuBundle, this fixed it. But don't know what _should_ be done.
