### PR TITLE
no longer force the locale to false on load if multilang is disabled

### DIFF
--- a/Doctrine/Phpcr/NonTranslatableMetadataListener.php
+++ b/Doctrine/Phpcr/NonTranslatableMetadataListener.php
@@ -33,7 +33,6 @@ class NonTranslatableMetadataListener implements EventSubscriber
     {
         return array(
             'loadClassMetadata',
-            'postLoad',
         );
     }
 
@@ -57,20 +56,6 @@ class NonTranslatableMetadataListener implements EventSubscriber
                 unset($meta->mappings[$meta->localeMapping]);
                 $meta->localeMapping = null;
             }
-        }
-    }
-
-    /**
-     * We set the locale field to false so that other code can use the
-     * information that translations are deactivated.
-     *
-     * @param LifecycleEventArgs $eventArgs
-     */
-    public function postLoad(LifecycleEventArgs $eventArgs)
-    {
-        $object = $eventArgs->getObject();
-        if ($object instanceof TranslatableInterface) {
-            $object->setLocale(false);
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes (anyone relying on the locale being false when multi lang is disabled) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony-cmf/MenuBundle/issues/126 |
| License | MIT |
| Doc PR | N/A |

this fixes issues with the Locale constraint
