### PR TITLE
when disabling translation mappings, also remove the translator

### DIFF
--- a/Doctrine/Phpcr/NonTranslatableMetadataListener.php
+++ b/Doctrine/Phpcr/NonTranslatableMetadataListener.php
@@ -56,6 +56,7 @@ class NonTranslatableMetadataListener implements EventSubscriber
                 unset($meta->mappings[$meta->localeMapping]);
                 $meta->localeMapping = null;
             }
+            $meta->translator = null;
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

actually I guess we should then also cherry pick this into 1.0
