### PR TITLE
revert a BC breaking name change

### DIFF
--- a/Resources/config/publish-workflow.xml
+++ b/Resources/config/publish-workflow.xml
@@ -51,7 +51,7 @@
 
         <!-- integration with sonata admin - removed by the DI class if sonata is not available -->
 
-        <service id="cmf_core.sonata_admin.extension.publish_workflow.publishable" class="%cmf_core.admin_extension.publish_workflow.publishable.class%">
+        <service id="cmf_core.admin_extension.publish_workflow.publishable" class="%cmf_core.admin_extension.publish_workflow.publishable.class%">
             <argument>%cmf_core.sonata_admin.extension.publishable.form_group%</argument>
             <tag name="sonata.admin.extension"/>
         </service>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes (reverting BC break compared to 1.0 - breaking for people who already updated to latest) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #115 |
| License | MIT |
| Doc PR | - |

this was - probably accidentally renamed. (the doc was never updated, no changelog entry about the break, and it was inconsistent as `cmf_core.admin_extension.publish_workflow.time_period` was not changed).

if we really want to clean up the names, we would need to define alias for the old names, and update the doc and add a changelog entry. okay to simply keep them as they where in 1.0?
