### PR TITLE
make semantics of getPrevLinkable / getNextLinkable consistent

### DIFF
--- a/Templating/Helper/CmfHelper.php
+++ b/Templating/Helper/CmfHelper.php
@@ -345,6 +345,8 @@ class CmfHelper extends Helper
      * @param string|null    $class      class name to filter on.
      *
      * @return array
+     *
+     * @see isLinkable
      */
     public function getLinkableChildren($parent, $limit = false, $offset = false, $filter = null, $ignoreRole = false, $class = null)
     {
@@ -720,30 +722,54 @@ class CmfHelper extends Helper
     /**
      * Gets the previous linkable document.
      *
+     * This has the same semantics as the isLinkable method.
+     *
      * @param string|object      $current    document instance or path from which to search
      * @param null|string|object $anchor     document instance or path which serves as an anchor from which to flatten the hierarchy
      * @param null|integer       $depth      depth up to which to traverse down the tree when an anchor is provided
      * @param Boolean            $ignoreRole if to ignore the role
      *
      * @return null|object
+     *
+     * @see isLinkable
      */
     public function getPrevLinkable($current, $anchor = null, $depth = null, $ignoreRole = false)
     {
-        return $this->getPrev($current, $anchor, $depth, $ignoreRole, 'Symfony\Cmf\Component\Routing\RouteReferrersReadInterface');
+        while ($candidate = $this->getPrev($current, $anchor, $depth, $ignoreRole)) {
+            if ($this->isLinkable($candidate)) {
+                return $candidate;
+            }
+
+            $current = $candidate;
+        }
+
+        return null;
     }
 
     /**
      * Gets the next linkable document.
      *
+     * This has the same semantics as the isLinkable method.
+     *
      * @param string|object      $current    document instance or path from which to search
      * @param null|string|object $anchor     document instance or path which serves as an anchor from which to flatten the hierarchy
      * @param null|integer       $depth      depth up to which to traverse down the tree when an anchor is provided
      * @param Boolean            $ignoreRole if to ignore the role
      *
      * @return null|object
+     *
+     * @see isLinkable
      */
     public function getNextLinkable($current, $anchor = null, $depth = null, $ignoreRole = false)
     {
-        return $this->getNext($current, $anchor, $depth, $ignoreRole, 'Symfony\Cmf\Component\Routing\RouteReferrersReadInterface');
+        while ($candidate = $this->getNext($current, $anchor, $depth, $ignoreRole)) {
+            if ($this->isLinkable($candidate)) {
+                return $candidate;
+            }
+
+            $current = $candidate;
+        }
+
+        return null;
     }
 }

--- a/Tests/Resources/Document/RouteAware.php
+++ b/Tests/Resources/Document/RouteAware.php
@@ -30,5 +30,6 @@ class RouteAware implements RouteReferrersReadInterface
 
     public function getRoutes()
     {
+        return array(1, 2);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #122 |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/pull/402 |

We started using isLinkable for getLinkableChildren, but not for getNext/PrevLinkable. This makes things consistent again.
