### PR TITLE
Add ChildInterface and ChildExtension

### DIFF
--- a/Admin/Extension/ChildExtension.php
+++ b/Admin/Extension/ChildExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2013 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Admin\Extension;
+
+use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Cmf\Bundle\CoreBundle\Model\ChildInterface;
+
+/**
+ * Admin extension to handle child models.
+ *
+ * @author Emmanuel Vella <vella.emmanuel@gmail.com>
+ */
+class ChildExtension extends AdminExtension
+{
+    /**
+     * Set a default parent if defined in the request
+     *
+     * {@inheritDoc}
+     */
+    public function alterNewInstance(AdminInterface $admin, $object)
+    {
+        if (!$object instanceof ChildInterface) {
+            throw new \InvalidArgumentException('Expected ChildInterface, got ' . get_class($object));
+        }
+
+        if ($admin->hasRequest() && $parentId = $admin->getRequest()->get('parent')) {
+            if ($parent = $admin->getModelManager()->find(null, $parentId)) {
+                $object->setParentDocument($parent);
+            }
+        }
+    }
+}

--- a/DependencyInjection/CmfCoreExtension.php
+++ b/DependencyInjection/CmfCoreExtension.php
@@ -201,6 +201,10 @@ class CmfCoreExtension extends Extension implements PrependExtensionInterface
 
             $templatingHelper = $container->getDefinition($this->getAlias() . '.templating.helper');
             $templatingHelper->replaceArgument(1, new Reference($config['persistence']['phpcr']['manager_registry']));
+
+            if ($config['persistence']['phpcr']['use_sonata_admin']) {
+                $this->loadSonataPhpcrAdmin($config, $loader, $container);
+            }
         }
         if ($config['publish_workflow']['enabled']) {
             $this->loadPublishWorkflow($config['publish_workflow'], $loader, $container);
@@ -227,6 +231,17 @@ class CmfCoreExtension extends Extension implements PrependExtensionInterface
         }
 
         $this->setupFormTypes($container, $loader);
+    }
+
+    public function loadSonataPhpcrAdmin($config, XmlFileLoader $loader, ContainerBuilder $container)
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if ('auto' === $config['persistence']['phpcr']['use_sonata_admin'] && !isset($bundles['SonataDoctrinePHPCRAdminBundle'])) {
+            return;
+        }
+
+        $loader->load('admin-phpcr.xml');
     }
 
     /**

--- a/Model/ChildInterface.php
+++ b/Model/ChildInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2013 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Model;
+
+/**
+ * An interface for models with a parent document.
+ */
+interface ChildInterface
+{
+    /**
+     * @param $parent object
+     */
+    public function setParentDocument($parent);
+
+    /**
+     * @return object
+     */
+    public function getParentDocument();
+}

--- a/Resources/config/admin-phpcr.xml
+++ b/Resources/config/admin-phpcr.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="cmf_core.admin_extension.child.class">Symfony\Cmf\Bundle\CoreBundle\Admin\Extension\ChildExtension</parameter>
+    </parameters>
+
+    <services>
+
+        <service id="cmf_core.admin_extension.child" class="%cmf_core.admin_extension.child.class%">
+            <tag name="sonata.admin.extension"/>
+        </service>
+
+    </services>
+</container>

--- a/Tests/Unit/Admin/Extensions/ChildExtensionTest.php
+++ b/Tests/Unit/Admin/Extensions/ChildExtensionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2013 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Unit\Admin\Extension;
+
+use Symfony\Cmf\Bundle\CoreBundle\Admin\Extension\ChildExtension;
+
+class ChildExtensionTest extends \PHPUnit_Framework_Testcase
+{
+    public function testAlterNewInstance()
+    {
+        $parent = new \StdClass;
+
+        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $modelManager->expects($this->any())
+            ->method('find')
+            ->will($this->returnValue($parent))
+        ;
+
+        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $request->expects($this->any())
+            ->method('get')
+            ->will($this->returnValue('parent-id'))
+        ;
+
+        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin->expects($this->any())
+            ->method('getModelManager')
+            ->will($this->returnValue($modelManager))
+        ;
+        $admin->expects($this->any())
+            ->method('hasRequest')
+            ->will($this->returnValue(true))
+        ;
+        $admin->expects($this->any())
+            ->method('getRequest')
+            ->will($this->returnValue($request))
+        ;
+
+        $child = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\Model\ChildInterface');
+        $child->expects($this->once())
+            ->method('setParentDocument')
+            ->with($this->equalTo($parent));
+
+        $extension = new ChildExtension();
+        $extension->alterNewInstance($admin, $child);
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/pull/408 |

Previously discussed in https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/236

To make it work, it currently requires the following config :

```
sonata_admin:
    extensions:
        cmf_core.admin_extension.child:
            implements:
                - Symfony\Cmf\Bundle\CoreBundle\Model\ChildInterface
```

If it's ok, I will update the docs.
