### PR TITLE
make child interface neutral, support hierarchyinterface as well

### DIFF
--- a/Model/ChildInterface.php
+++ b/Model/ChildInterface.php
@@ -12,17 +12,20 @@
 namespace Symfony\Cmf\Bundle\CoreBundle\Model;
 
 /**
- * An interface for models with a parent document.
+ * An interface for models with a parent object.
+ *
+ * Note that PHPCR-ODM documents will most likely use the HierarchyInterface
+ * of PHPCR-ODM instead.
  */
 interface ChildInterface
 {
     /**
      * @param $parent object
      */
-    public function setParentDocument($parent);
+    public function setParentObject($parent);
 
     /**
      * @return object
      */
-    public function getParentDocument();
+    public function getParentObject();
 }

--- a/Tests/Unit/Admin/Extension/ChildExtensionTest.php
+++ b/Tests/Unit/Admin/Extension/ChildExtensionTest.php
@@ -50,7 +50,7 @@ class ChildExtensionTest extends \PHPUnit_Framework_Testcase
 
         $child = $this->getMock('Symfony\Cmf\Bundle\CoreBundle\Model\ChildInterface');
         $child->expects($this->once())
-            ->method('setParentDocument')
+            ->method('setParentObject')
             ->with($this->equalTo($parent));
 
         $extension = new ChildExtension();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | only with regard to the previous RC |
| Deprecations? | no |
| Tests pass? | travis |
| Fixed tickets | #137 |
| License | MIT |
| Doc PR | https://github.com/symfony-cmf/symfony-cmf-docs/issues/471 |

This would rid us of the dependency confusion we introduced with the ChildInterface.
