### PR TITLE
apply non-multilang to all phpcr-odm documents regardless of implemented interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.1.0
+-----
+
+* **2014-05-08** [Multilang]: When using phpcr-odm but not configuring
+  cmf_core.multilang.locales, the metadata listener now makes all documents
+  non-translated. It no longer checks whether the document implements
+  `TranslatableInterface`.
+
 1.1.0-RC2
 ---------
 

--- a/Doctrine/Phpcr/NonTranslatableMetadataListener.php
+++ b/Doctrine/Phpcr/NonTranslatableMetadataListener.php
@@ -45,16 +45,18 @@ class NonTranslatableMetadataListener implements EventSubscriber
         /** @var $meta ClassMetadata */
         $meta = $eventArgs->getClassMetadata();
 
-        if ($meta->getReflectionClass()->implementsInterface('Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface')) {
-            foreach ($meta->translatableFields as $field) {
-                unset($meta->mappings[$field]['translated']);
-            }
-            $meta->translatableFields = array();
-            if (null !== $meta->localeMapping) {
-                unset($meta->mappings[$meta->localeMapping]);
-                $meta->localeMapping = null;
-            }
-            $meta->translator = null;
+        if (!$meta->translator) {
+            return;
         }
+
+        foreach ($meta->translatableFields as $field) {
+            unset($meta->mappings[$field]['translated']);
+        }
+        $meta->translatableFields = array();
+        if (null !== $meta->localeMapping) {
+            unset($meta->mappings[$meta->localeMapping]);
+            $meta->localeMapping = null;
+        }
+        $meta->translator = null;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | not really |
| Deprecations? | no |
| Tests pass? | travis |
| Fixed tickets | https://github.com/symfony-cmf/SeoBundle/issues/161 |
| License | MIT |
| Doc PR | \- (its already claiming things work as this PR will make them work) |
