### PR TITLE
Workaround travis phpunit mixup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ env:
 before_script:
   - composer self-update
   - composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source
+  # this should not be needed, but travis ends up with an unhealthy mix between phpunit 3 and 4
+  - wget https://phar.phpunit.de/phpunit-lts.phar
 
-script: phpunit --coverage-text
+script: ./phpunit-lts.phar --coverage-text
 
 notifications:
   irc: "irc.freenode.org#symfony-cmf"


### PR DESCRIPTION
this should fix the build. 

the error on travis makes no sense whatsoever: https://travis-ci.org/symfony-cmf/CoreBundle/jobs/27420033 

PHPUnit 3.7.37 by Sebastian Bergmann.

PHP Fatal error: Call to undefined method PHPUnit_Util_Test::getHookMethods() in phar:///home/travis/.phpenv/versions/5.3.27/bin/phpunit/phpunit/Framework/TestCase.php on line 800

phpunit 3.7.37 has some different code on line 800. getHookMethods is phpunit 4 only. and travis seems not to be generally using a broken phpunit version - all other bundles still work as they should.
