### PR TITLE
use PHPUnit version from the vendors and fix test case class name

### DIFF
--- a/Tests/Unit/Admin/Extension/ChildExtensionTest.php
+++ b/Tests/Unit/Admin/Extension/ChildExtensionTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Unit\Admin\Extension;
 
 use Symfony\Cmf\Bundle\CoreBundle\Admin\Extension\ChildExtension;
 
-class ChildExtensionTest extends \PHPUnit_Framework_Testcase
+class ChildExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testAlterNewInstance()
     {

--- a/Tests/Unit/Admin/Extension/PublishTimePeriodExtensionTest.php
+++ b/Tests/Unit/Admin/Extension/PublishTimePeriodExtensionTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Unit\Admin\Extension;
 
 use Symfony\Cmf\Bundle\CoreBundle\Admin\Extension\PublishTimePeriodExtension;
 
-class PublishTimePeriodExtensionTest extends \PHPUnit_Framework_Testcase
+class PublishTimePeriodExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {

--- a/Tests/Unit/Admin/Extension/PublishableExtensionTest.php
+++ b/Tests/Unit/Admin/Extension/PublishableExtensionTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Unit\Admin\Extension;
 
 use Symfony\Cmf\Bundle\CoreBundle\Admin\Extension\PublishableExtension;
 
-class PublishableExtensionTest extends \PHPUnit_Framework_Testcase
+class PublishableExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {

--- a/Tests/Unit/Admin/Extension/TranslatableExtensionTest.php
+++ b/Tests/Unit/Admin/Extension/TranslatableExtensionTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Unit\Admin\Extension;
 
 use Symfony\Cmf\Bundle\CoreBundle\Admin\Extension\TranslatableExtension;
 
-class TranslatableExtensionTest extends \PHPUnit_Framework_Testcase
+class TranslatableExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {

--- a/Tests/Unit/PublishWorkflow/PublishWorkflowCheckerTest.php
+++ b/Tests/Unit/PublishWorkflow/PublishWorkflowCheckerTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
-class PublishWorkflowCheckerTest extends \PHPUnit_Framework_Testcase
+class PublishWorkflowCheckerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var PublishWorkflowChecker

--- a/Tests/Unit/PublishWorkflow/Voter/PublishTimePeriodVoterTest.php
+++ b/Tests/Unit/PublishWorkflow/Voter/PublishTimePeriodVoterTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class PublishTimePeriodVoterTest extends \PHPUnit_Framework_Testcase
+class PublishTimePeriodVoterTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var PublishTimePeriodVoter

--- a/Tests/Unit/PublishWorkflow/Voter/PublishableVoterTest.php
+++ b/Tests/Unit/PublishWorkflow/Voter/PublishableVoterTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class PublishableVoterTest extends \PHPUnit_Framework_Testcase
+class PublishableVoterTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var PublishableVoter


### PR DESCRIPTION
Travis builds currently fail because PHPUnit 4 is used but some of the dependencies load parts of PHPUnit 3.7.
