### PR TITLE
[RFC][POC] Add full Symfony 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -15,19 +13,16 @@ cache:
     - $HOME/.composer/cache/files
 
 env:
-  global:
-    - SYMFONY_DEPRECATIONS_HELPER=7
+  - SYMFONY_VERSION=2.8.*
 
 matrix:
   include:
-    - php: 5.6
-      env: DEPS=dev SYMFONY_VERSION=2.8.*
-    - php: 5.3
+    - php: 7.0
+      env: DEPS=dev SYMFONY_VERSION=3.1.*
+    - php: 5.5
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.6
-      env: SYMFONY_VERSION=2.3.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.*
+    - php: 7.0
+      env: DEPS=dev COMPOSER_FLAGS="--prefer-stable" SYMFONY_VERSION=3.0.*
   fast_finish: true
 
 before_install:

--- a/Admin/Extension/PublishTimePeriodExtension.php
+++ b/Admin/Extension/PublishTimePeriodExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Cmf\Bundle\CoreBundle\Admin\Extension;
 
 use Sonata\AdminBundle\Admin\AdminExtension;
 use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 
 /**
  * Admin extension to add publish workflow time period fields for models
@@ -40,21 +41,19 @@ class PublishTimePeriodExtension extends AdminExtension
      */
     public function configureFormFields(FormMapper $formMapper)
     {
-        $dateType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ? 'Symfony\Component\Form\Extension\Core\Type\DateType' : 'date';
         $dateOptions = array(
             'empty_value' => '',
             'required' => false,
         );
 
-        $formMapper->with($this->formGroup, array(
-            'translation_domain' => 'CmfCoreBundle',
-            ))
-            ->add('publish_start_date', $dateType, $dateOptions, array(
-                'help' => 'form.help_publish_start_date',
-            ))
-            ->add('publish_end_date', $dateType, $dateOptions, array(
-                'help' => 'form.help_publish_end_date',
-            ))
+        $formMapper
+            ->with($this->formGroup, array('translation_domain' => 'CmfCoreBundle'))
+                ->add('publish_start_date', DateType::class, $dateOptions, array(
+                    'help' => 'form.help_publish_start_date',
+                ))
+                ->add('publish_end_date', DateType::class, $dateOptions, array(
+                    'help' => 'form.help_publish_end_date',
+                ))
             ->end();
     }
 }

--- a/Admin/Extension/PublishableExtension.php
+++ b/Admin/Extension/PublishableExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Cmf\Bundle\CoreBundle\Admin\Extension;
 
 use Sonata\AdminBundle\Admin\AdminExtension;
 use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 /**
  * Admin extension to add a publish workflow publishable field for models
@@ -40,12 +41,11 @@ class PublishableExtension extends AdminExtension
      */
     public function configureFormFields(FormMapper $formMapper)
     {
-        $formMapper->with($this->formGroup, array(
-            'translation_domain' => 'CmfCoreBundle',
-            ))
-            ->add('publishable', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ? 'Symfony\Component\Form\Extension\Core\Type\CheckboxType' : 'checkbox', array(
-                'required' => false,
-            ))
+        $formMapper
+            ->with($this->formGroup, array('translation_domain' => 'CmfCoreBundle'))
+                ->add('publishable', CheckboxType::class, array(
+                    'required' => false,
+                ))
             ->end();
     }
 }

--- a/Admin/Extension/TranslatableExtension.php
+++ b/Admin/Extension/TranslatableExtension.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 
 /**
  * Admin extension to add publish workflow time period fields.
@@ -69,7 +70,7 @@ class TranslatableExtension extends AdminExtension
         $formMapper
             ->with($this->formGroup)
             // do not set a translation_domain for this group or group_general will be translated by our domain.
-            ->add('locale', method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ? 'Symfony\Component\Form\Extension\Core\Type\ChoiceType' : 'choice', array(
+            ->add('locale', ChoiceType::class, array(
                 'choices' => array_combine($this->locales, $this->locales),
                 'empty_value' => '',
             ), array('translation_domain' => 'CmfCoreBundle'))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 Changelog
 =========
+
+ * **2016-04-30**: [BC BREAK] Dropped PHP <5.5 support
+ * **2016-04-30**: [BC BREAK] Dropped Symfony <2.8 support
+
 1.3.0
 -----
+
+Released 1.3.0
 
 1.3.0-RC1
 ---------

--- a/Form/Type/CheckboxUrlLabelFormType.php
+++ b/Form/Type/CheckboxUrlLabelFormType.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Bundle\CoreBundle\Form\Type;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -100,6 +101,6 @@ class CheckboxUrlLabelFormType extends AbstractType
      */
     public function getParent()
     {
-        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix') ? 'Symfony\Component\Form\Extension\Core\Type\CheckboxType' : 'checkbox';
+        return CheckboxType::class;
     }
 }

--- a/PublishWorkflow/AlwaysPublishedWorkflowChecker.php
+++ b/PublishWorkflow/AlwaysPublishedWorkflowChecker.php
@@ -11,8 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow;
 
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * A placeholder service to provide instead of the normal publish workflow
@@ -24,20 +23,8 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
-class AlwaysPublishedWorkflowChecker implements SecurityContextInterface
+class AlwaysPublishedWorkflowChecker implements AuthorizationCheckerInterface
 {
-    public function getToken()
-    {
-        return;
-    }
-
-    /**
-     * Ignored.
-     */
-    public function setToken(TokenInterface $token = null)
-    {
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/PublishWorkflow/Voter/PublishTimePeriodVoter.php
+++ b/PublishWorkflow/Voter/PublishTimePeriodVoter.php
@@ -47,6 +47,8 @@ class PublishTimePeriodVoter implements VoterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated To be removed when Symfony 2 support is dropped
      */
     public function supportsAttribute($attribute)
     {
@@ -57,10 +59,12 @@ class PublishTimePeriodVoter implements VoterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated To be removed when Symfony 2 support is dropped
      */
     public function supportsClass($class)
     {
-        return is_subclass_of($class, 'Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodReadInterface');
+        return is_subclass_of($class, PublishTimePeriodReadInterface::class);
     }
 
     /**
@@ -87,8 +91,9 @@ class PublishTimePeriodVoter implements VoterInterface
                 continue;
             }
 
-            if ((null !== $startDate && $this->currentTime < $startDate) ||
-                (null !== $endDate && $this->currentTime > $endDate)
+            if (
+                (null !== $startDate && $this->currentTime < $startDate)
+                || (null !== $endDate && $this->currentTime > $endDate)
             ) {
                 return self::ACCESS_DENIED;
             }

--- a/PublishWorkflow/Voter/PublishableVoter.php
+++ b/PublishWorkflow/Voter/PublishableVoter.php
@@ -25,6 +25,8 @@ class PublishableVoter implements VoterInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @deprecated To be removed when Symfony 2 support is dropped
      */
     public function supportsAttribute($attribute)
     {
@@ -35,10 +37,12 @@ class PublishableVoter implements VoterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated To be removed when Symfony 2 support is dropped
      */
     public function supportsClass($class)
     {
-        return is_subclass_of($class, 'Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface');
+        return is_subclass_of($class, PublishableReadInterface::class);
     }
 
     /**
@@ -61,6 +65,7 @@ class PublishableVoter implements VoterInterface
                 $decision = self::ACCESS_ABSTAIN;
                 continue;
             }
+
             if (!$object->isPublishable()) {
                 return self::ACCESS_DENIED;
             }

--- a/Resources/config/publish-workflow.xml
+++ b/Resources/config/publish-workflow.xml
@@ -24,7 +24,8 @@
         </service>
 
         <service id="cmf_core.publish_workflow.checker.default" class="%cmf_core.publish_workflow.checker.class%">
-            <argument type="service" id="service_container"/>
+            <argument type="service" id="security.token_storage"/>
+            <argument type="service" id="security.authorization_checker"/>
             <argument type="service" id="cmf_core.publish_workflow.access_decision_manager"/>
             <argument>%cmf_core.publish_workflow.view_non_published_role%</argument>
         </service>

--- a/Templating/Helper/CmfHelper.php
+++ b/Templating/Helper/CmfHelper.php
@@ -19,7 +19,7 @@ use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Templating\Helper\Helper;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
 
 /**
@@ -45,7 +45,7 @@ class CmfHelper extends Helper
     protected $dm;
 
     /**
-     * @var SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
     protected $publishWorkflowChecker;
 
@@ -54,12 +54,12 @@ class CmfHelper extends Helper
      * setDcotrineRegistry in order to avoid circular dependencies when a
      * doctrine event listener needs twig injected.
      *
-     * @param SecurityContextInterface $publishWorkflowChecker
-     * @param ManagerRegistry          $registry               For loading PHPCR-ODM documents from
-     *                                                         Doctrine.
-     * @param string                   $managerName
+     * @param AuthorizationCheckerInterface $publishWorkflowChecker
+     * @param ManagerRegistry               $registry               For loading PHPCR-ODM documents from
+     *                                                              Doctrine.
+     * @param string                        $managerName
      */
-    public function __construct(SecurityContextInterface $publishWorkflowChecker = null, $registry = null, $managerName = null)
+    public function __construct(AuthorizationCheckerInterface $publishWorkflowChecker = null, $registry = null, $managerName = null)
     {
         $this->publishWorkflowChecker = $publishWorkflowChecker;
         $this->setDoctrineRegistry($registry, $managerName);

--- a/Tests/Functional/Form/CheckboxUrlLabelFormTypeTest.php
+++ b/Tests/Functional/Form/CheckboxUrlLabelFormTypeTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Functional\Form;
 
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+use Symfony\Cmf\Bundle\CoreBundle\Form\Type\CheckboxUrlLabelFormType;
 
 class CheckboxUrlLabelFormTypeTest extends BaseTestCase
 {
@@ -26,8 +27,8 @@ class CheckboxUrlLabelFormTypeTest extends BaseTestCase
         $this->getContainer()->get('twig')->initRuntime();
         $renderer = $this->getContainer()->get('twig')->getExtension('form')->renderer;
 
-        $view = $this->getContainer()->get('form.factory')->createNamedBuilder('name', 'form')
-            ->add('terms', 'cmf_core_checkbox_url_label', array(
+        $view = $this->getContainer()->get('form.factory')->createNamedBuilder('name')
+            ->add('terms', CheckboxUrlLabelFormType::class, array(
                 'label' => '%a% and %b% and %c%',
                 'routes' => array(
                     '%a%' => array('parameters' => array('content_id' => '/test/content/a')),

--- a/Tests/Functional/PublishWorkflow/PublishWorkflowTest.php
+++ b/Tests/Functional/PublishWorkflow/PublishWorkflowTest.php
@@ -16,7 +16,6 @@ use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodReadInterface
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Role\Role;
-use Symfony\Component\Security\Core\SecurityContext;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
 
@@ -25,11 +24,11 @@ class PublishWorkflowTest extends BaseTestCase
     /**
      * @var SecurityContextInterface
      */
-    private $pwc;
+    private $publishWorkflowChecker;
 
     public function setUp()
     {
-        $this->pwc = $this->getContainer()->get('cmf_core.publish_workflow.checker');
+        $this->publishWorkflowChecker = $this->getContainer()->get('cmf_core.publish_workflow.checker');
     }
 
     public function testPublishable()
@@ -40,8 +39,8 @@ class PublishWorkflowTest extends BaseTestCase
             ->will($this->returnValue(true))
         ;
 
-        $this->assertTrue($this->pwc->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $doc));
-        $this->assertTrue($this->pwc->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $doc));
+        $this->assertTrue($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $doc));
+        $this->assertTrue($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $doc));
     }
 
     public function testPublishPeriod()
@@ -56,8 +55,8 @@ class PublishWorkflowTest extends BaseTestCase
             ->will($this->returnValue(new \DateTime('01/01/1980')))
         ;
 
-        $this->assertFalse($this->pwc->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $doc));
-        $this->assertFalse($this->pwc->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $doc));
+        $this->assertFalse($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $doc));
+        $this->assertFalse($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $doc));
     }
 
     public function testIgnoreRoleHas()
@@ -71,11 +70,11 @@ class PublishWorkflowTest extends BaseTestCase
             new Role('ROLE_CAN_VIEW_NON_PUBLISHED'),
         );
         $token = new UsernamePasswordToken('test', 'pass', 'testprovider', $roles);
-        $context = $this->getContainer()->get('security.context');
-        $context->setToken($token);
+        $tokenStorage = $this->getContainer()->get('security.token_storage');
+        $tokenStorage->setToken($token);
 
-        $this->assertTrue($this->pwc->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $doc));
-        $this->assertFalse($this->pwc->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $doc));
+        $this->assertTrue($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $doc));
+        $this->assertFalse($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $doc));
     }
 
     public function testIgnoreRoleNotHas()
@@ -89,12 +88,11 @@ class PublishWorkflowTest extends BaseTestCase
             new Role('OTHER_ROLE'),
         );
         $token = new UsernamePasswordToken('test', 'pass', 'testprovider', $roles);
-        /** @var $context SecurityContext */
-        $context = $this->getContainer()->get('security.context');
-        $context->setToken($token);
+        $tokenStorage = $this->getContainer()->get('security.token_storage');
+        $tokenStorage->setToken($token);
 
-        $this->assertFalse($this->pwc->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $doc));
-        $this->assertFalse($this->pwc->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $doc));
+        $this->assertFalse($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $doc));
+        $this->assertFalse($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $doc));
     }
 }
 

--- a/Tests/Functional/Templating/Helper/CmfHelperHierarchyTest.php
+++ b/Tests/Functional/Templating/Helper/CmfHelperHierarchyTest.php
@@ -20,7 +20,7 @@ class CmfHelperHierarchyTest extends BaseTestCase
     /**
      * @var SecurityContextInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $pwc;
+    private $publishWorkflowChecker;
 
     /**
      * @var CmfHelper
@@ -32,13 +32,13 @@ class CmfHelperHierarchyTest extends BaseTestCase
         $dbManager = $this->db('PHPCR');
         $dbManager->loadFixtures(array('Symfony\Cmf\Bundle\CoreBundle\Tests\Resources\DataFixture\LoadHierarchyRouteData'));
 
-        $this->pwc = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $this->pwc->expects($this->any())
+        $this->publishWorkflowChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $this->publishWorkflowChecker->expects($this->any())
             ->method('isGranted')
             ->will($this->returnValue(true))
         ;
 
-        $this->helper = new CmfHelper($this->pwc, $dbManager->getRegistry(), 'default');
+        $this->helper = new CmfHelper($this->publishWorkflowChecker, $dbManager->getRegistry(), 'default');
     }
 
     public function testGetDescendants()

--- a/Tests/Resources/app/config/cmf_routing.yml
+++ b/Tests/Resources/app/config/cmf_routing.yml
@@ -8,4 +8,4 @@ cmf_routing:
         persistence:
             phpcr:
                 enabled: true
-                route_basepath: /test/cms/routes
+                route_basepaths: [/test/cms/routes]

--- a/Tests/Resources/app/config/config.php
+++ b/Tests/Resources/app/config/config.php
@@ -14,3 +14,7 @@ $loader->import(CMF_TEST_CONFIG_DIR.'/default.php');
 $loader->import(CMF_TEST_CONFIG_DIR.'/phpcr_odm.php');
 $loader->import(__DIR__.'/cmf_core.yml');
 $loader->import(__DIR__.'/cmf_routing.yml');
+
+$container->loadFromExtension('framework', array(
+    'csrf_protection' => true,
+));

--- a/Tests/Unit/Form/CheckboxUrlLabelFormTypeTest.php
+++ b/Tests/Unit/Form/CheckboxUrlLabelFormTypeTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Unit\Form;
 
-use Symfony\Component\Form\AbstractExtension;
+use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Cmf\Bundle\CoreBundle\Form\Type\CheckboxUrlLabelFormType;
 use Symfony\Component\Routing\RequestContext;
@@ -41,21 +41,11 @@ class Router implements RouterInterface
     }
 }
 
-class CmfCoreExtension extends AbstractExtension
-{
-    protected function loadTypes()
-    {
-        return array(
-            new CheckboxUrlLabelFormType(new Router()),
-        );
-    }
-}
-
 class CheckboxUrlLabelFormTypeTest extends TypeTestCase
 {
     public function testContentPathsAreSet()
     {
-        $checkboxUrlLabelForm = $this->factory->create('cmf_core_checkbox_url_label', null, array(
+        $checkboxUrlLabelForm = $this->factory->create(CheckboxUrlLabelFormType::class, null, array(
             'routes' => array('a' => array('name' => 'a'), 'b' => array('name' => 'b')),
         ));
         $view = $checkboxUrlLabelForm->createView();
@@ -66,6 +56,10 @@ class CheckboxUrlLabelFormTypeTest extends TypeTestCase
 
     protected function getExtensions()
     {
-        return array_merge(parent::getExtensions(), array(new CmfCoreExtension()));
+        return array_merge(parent::getExtensions(), array(
+            new PreloadedExtension(array(
+                CheckboxUrlLabelFormType::class => new CheckboxUrlLabelFormType(new Router()),
+            ), array()),
+        ));
     }
 }

--- a/Tests/Unit/PublishWorkflow/PublishWorkflowCheckerTest.php
+++ b/Tests/Unit/PublishWorkflow/PublishWorkflowCheckerTest.php
@@ -11,62 +11,32 @@
 
 namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Unit\PublishWorkflow;
 
-use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface;
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
-use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
 
 class PublishWorkflowCheckerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var PublishWorkflowChecker
-     */
-    private $pwfc;
-
-    /**
-     * @var string
-     */
+    private $publishWorkflowChecker;
     private $role;
-
-    /**
-     * @var ContainerInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $container;
-
-    /**
-     * @var SecurityContextInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $sc;
-
-    /**
-     * @var PublishableReadInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $doc;
-
-    /**
-     * @var AccessDecisionManagerInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
-    private $adm;
+    private $document;
+    private $accessDecisionManager;
+    private $authorizationChecker;
+    private $tokenStorage;
 
     public function setUp()
     {
         $this->role = 'IS_FOOBAR';
-        $this->container = \Mockery::mock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->sc = \Mockery::mock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $this->doc = \Mockery::mock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface');
-        $this->adm = \Mockery::mock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface');
-        $this->stdClass = new \stdClass();
-        $this->pwfc = new PublishWorkflowChecker($this->container, $this->adm, $this->role);
+        $this->authorizationChecker = \Mockery::mock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $this->tokenStorage = \Mockery::mock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $this->document = \Mockery::mock('Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface');
+        $this->accessDecisionManager = \Mockery::mock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface');
 
-        $this->container->shouldReceive('get')->with('security.context')->andReturn($this->sc);
-
-        // assuming Symfony <2.6
-        $this->container->shouldReceive('has')->with('security.context')->andReturn(true);
-        $this->container->shouldReceive('has')->with('security.token_storage')->andReturn(false);
-        $this->container->shouldReceive('has')->with('security.authorization_checker')->andReturn(false);
+        $this->publishWorkflowChecker = new PublishWorkflowChecker(
+            $this->tokenStorage,
+            $this->authorizationChecker,
+            $this->accessDecisionManager,
+            $this->role
+        );
     }
 
     protected function tearDown()
@@ -74,107 +44,67 @@ class PublishWorkflowCheckerTest extends \PHPUnit_Framework_TestCase
         \Mockery::close();
     }
 
-    /**
-     * Calling.
-     */
     public function testIsGranted()
     {
         $token = new AnonymousToken('', '');
-        $this->sc->shouldReceive('getToken')->andReturn($token);
-        $this->sc->shouldNotReceive('isGranted');
-        $this->adm
+        $this->tokenStorage->shouldReceive('getToken')->andReturn($token);
+
+        $this->authorizationChecker->shouldNotReceive('isGranted');
+
+        $this->accessDecisionManager
             ->shouldReceive('decide')->once()
-            ->with($token, array(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE), $this->doc)
+            ->with($token, array(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE), $this->document)
             ->andReturn(true);
 
-        $this->assertTrue($this->pwfc->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $this->doc));
+        $this->assertTrue($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $this->document));
     }
 
     public function testNotHasBypassRole()
     {
         $token = new AnonymousToken('', '');
-        $this->sc->shouldReceive('getToken')->andReturn($token);
-        $this->sc->shouldReceive('isGranted')->once()->with($this->role)->andReturn(false);
-        $this->adm
+        $this->tokenStorage->shouldReceive('getToken')->andReturn($token);
+
+        $this->authorizationChecker->shouldReceive('isGranted')->once()->with($this->role)->andReturn(false);
+
+        $this->accessDecisionManager
             ->shouldReceive('decide')->once()
-            ->with($token, array(PublishWorkflowChecker::VIEW_ATTRIBUTE), $this->doc)
+            ->with($token, array(PublishWorkflowChecker::VIEW_ATTRIBUTE), $this->document)
             ->andReturn(true);
 
-        $this->assertTrue($this->pwfc->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $this->doc));
+        $this->assertTrue($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $this->document));
     }
 
     public function testHasBypassRole()
     {
         $token = new AnonymousToken('', '');
-        $this->sc->shouldReceive('getToken')->andReturn($token);
-        $this->sc->shouldReceive('isGranted')->once()->with($this->role)->andReturn(true);
-        $this->adm->shouldNotReceive('decide');
+        $this->tokenStorage->shouldReceive('getToken')->andReturn($token);
 
-        $this->assertTrue($this->pwfc->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $this->doc));
+        $this->authorizationChecker->shouldReceive('isGranted')->once()->with($this->role)->andReturn(true);
+
+        $this->accessDecisionManager->shouldNotReceive('decide');
+
+        $this->assertTrue($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $this->document));
     }
 
     public function testNoFirewall()
     {
-        $this->sc->shouldReceive('getToken')->andReturnNull();
-        $this->sc->shouldNotReceive('isGranted');
-        $this->adm
+        $this->tokenStorage->shouldReceive('getToken')->andReturnNull();
+
+        $this->authorizationChecker->shouldNotReceive('isGranted');
+
+        $this->accessDecisionManager
             ->shouldReceive('decide')->once()
-            ->with(\Mockery::type('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken'), array(PublishWorkflowChecker::VIEW_ATTRIBUTE), $this->doc)
+            ->with(\Mockery::type('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken'), array(PublishWorkflowChecker::VIEW_ATTRIBUTE), $this->document)
             ->andReturn(true);
 
-        $this->assertTrue($this->pwfc->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $this->doc));
-    }
-
-    public function testNoSecurityContext()
-    {
-        $container = \Mockery::mock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container->shouldReceive('get')->with('security.context')
-            ->andThrow(new ServiceNotFoundException('Service not defined'));
-        $container->shouldReceive('has')->andReturn(false);
-
-        $pwfc = new PublishWorkflowChecker($container, $this->adm, $this->role);
-
-        $this->adm->shouldReceive('decide')->once()->andReturn(false);
-
-        $this->assertFalse($pwfc->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $this->doc));
-    }
-
-    public function testSetToken()
-    {
-        $token = new AnonymousToken('x', 'y');
-        $this->pwfc->setToken($token);
-        $this->assertSame($token, $this->pwfc->getToken());
-    }
-
-    public function testTokenStorageAndAuthenticationManager()
-    {
-        if (!class_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage')) {
-            $this->markTestSkipped('This test requires Symfony >2.6');
-        }
-
-        $token = new AnonymousToken('x', 'y');
-        $ts = \Mockery::mock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInteface');
-        $ac = \Mockery::mock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-
-        $container = \Mockery::mock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container->shouldReceive('get')->with('security.token_storage')->andReturn($ts);
-        $container->shouldReceive('get')->with('security.authorization_checker')->andReturn($ac);
-        $container->shouldReceive('has')->with('security.token_storage')->andReturn(true);
-        $container->shouldReceive('has')->with('security.authorization_checker')->andReturn(true);
-
-        $ts->shouldReceive('getToken')->andReturn($token);
-        $ac->shouldReceive('isGranted')->with($this->role)->andReturn(true);
-
-        $pwfc = new PublishWorkflowChecker($container, $this->adm, $this->role);
-
-        $this->assertTrue($pwfc->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $this->doc));
+        $this->assertTrue($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $this->document));
     }
 
     public function testSupportsClass()
     {
         $class = 'Test\Class';
-        $this->adm->shouldReceive('supportsClass')->once()->with($class)->andReturn(true);
+        $this->accessDecisionManager->shouldReceive('supportsClass')->once()->with($class)->andReturn(true);
 
-        $this->assertTrue($this->pwfc->supportsClass($class));
+        $this->assertTrue($this->publishWorkflowChecker->supportsClass($class));
     }
 }

--- a/Tests/Unit/Templating/Helper/CmfHelperTest.php
+++ b/Tests/Unit/Templating/Helper/CmfHelperTest.php
@@ -27,7 +27,7 @@ class CmfHelperTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->pwc = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $this->pwc = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
 
         $this->managerRegistry = $this->getMockBuilder('Doctrine\Bundle\PHPCRBundle\ManagerRegistry')
             ->disableOriginalConstructor()

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
         }
     ],
     "require": {
-        "php": "^5.3.9|^7.0",
-        "symfony/framework-bundle": "^2.3",
+        "php": "^5.5.9|^7.0",
+        "symfony/framework-bundle": "^2.8|^3.0",
         "symfony-cmf/slugifier-api": "^1.0"
     },
     "require-dev": {
-        "symfony/security-bundle": "^2.1",
+        "symfony/security-bundle": "^2.8|^3.0",
         "mockery/mockery": "^0.9.4",
-        "symfony-cmf/routing-bundle": "^1.2",
+        "symfony-cmf/routing-bundle": "^1.2|^2.0",
         "symfony-cmf/testing": "^1.3",
-        "sonata-project/admin-bundle": "^2.2",
+        "sonata-project/doctrine-phpcr-admin-bundle": "^1.2.3|^2.0",
         "doctrine/dbal": "2.5.*"
     },
     "suggest": {


### PR DESCRIPTION
 I feel like releasing a version without Symfony 3 support is not a great move at the moment. So I tried to find out what is needed to support Symfony 3. Turns out it means major breaks for this bundle, including dropping Symfony 2.3 support.

We need to discuss if this is a problem or not. As far as I can see, we don't need such major breaks in other CMF bundles to support Symfony 3 (just some ugly lines of code). I don't think it's a huge problem, because:

 * CMF 1.2 still works perfectly on Symfony 2.3 and is quite stable
 * Symfony 2.3 will reach end of maintenance in May 2016
 * There are no BC breaks between Symfony 2.3 and Symfony 2.7/2.8 (the next LTS releases), so it should be quite a smooth upgrade process (in fact, I don't know why, or even if, people are using 2.3 nowadays)

/cc @dantleech @lsmith77 @dbu 