### PR TITLE
Fix wrong publish workflow class when disabled

### DIFF
--- a/Resources/config/no-publish-workflow.xml
+++ b/Resources/config/no-publish-workflow.xml
@@ -6,7 +6,7 @@
 
     <services>
 
-        <service id="cmf_core.publish_workflow.checker" class="Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker"/>
+        <service id="cmf_core.publish_workflow.checker" class="Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\AlwaysPublishedWorkflowChecker"/>
 
     </services>
 </container>

--- a/Tests/Functional/DependencyInjection/CmfCoreExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/CmfCoreExtensionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Functional\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Cmf\Bundle\CoreBundle\DependencyInjection\CmfCoreExtension;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\AlwaysPublishedWorkflowChecker;
+
+class CmfCoreExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    private $container;
+
+    protected function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        $this->container->registerExtension(new CmfCoreExtension());
+        $this->container->setParameter('kernel.bundles', array('CmfCoreBundle' => true));
+    }
+
+    public function testPublishWorkflowDisabled()
+    {
+        $this->container->loadFromExtension('cmf_core', [
+            'publish_workflow' => false,
+        ]);
+
+        $this->container->setAlias('app.workflow_checker', 'cmf_core.publish_workflow.checker');
+
+        $this->container->compile();
+
+        $this->assertInstanceOf(AlwaysPublishedWorkflowChecker::class, $this->container->get('app.workflow_checker'));
+    }
+}


### PR DESCRIPTION
My automation tool got confused, because the class name was overridden. This fixes the little introduced bug.

Also added a test to prevent this from happening again.