### PR TITLE
Add cmf_find_translation twig function

### DIFF
--- a/Templating/Helper/CmfHelper.php
+++ b/Templating/Helper/CmfHelper.php
@@ -168,6 +168,26 @@ class CmfHelper extends Helper
     }
 
     /**
+     * Finds a document by path and locale.
+     *
+     * @param string|object $pathOrDocument the identifier of the class (path or document object)
+     * @param string        $locale         the language to try to load
+     * @param bool          $fallback       set to true if the language fallback mechanism should be used
+     *
+     * @return null|object
+     */
+    public function findTranslation($pathOrDocument, $locale, $fallback = true)
+    {
+        if (is_object($pathOrDocument)) {
+            $path = $this->getDm()->getUnitOfWork()->getDocumentId($pathOrDocument);
+        } else {
+            $path = $pathOrDocument;
+        }
+
+        return $this->getDm()->findTranslation(null, $path, $locale, $fallback);
+    }
+
+    /**
      * Gets a document instance and validate if its eligible.
      *
      * @param string|object $document   the id of a document or the document

--- a/Tests/Unit/Templating/Helper/CmfHelperTest.php
+++ b/Tests/Unit/Templating/Helper/CmfHelperTest.php
@@ -137,6 +137,20 @@ class CmfHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($document, $this->extension->find('/foo'));
     }
 
+    public function testFindTranslation()
+    {
+        $document = new \stdClass();
+
+        $this->manager->expects($this->any())
+            ->method('findTranslation')
+            ->with(null, '/foo', 'en')
+            ->will($this->onConsecutiveCalls(null, $document, 'en'))
+        ;
+
+        $this->assertNull($this->extension->findTranslation('/foo', 'en'));
+        $this->assertEquals($document, $this->extension->findTranslation('/foo', 'en'));
+    }
+
     public function testFindMany()
     {
         $this->assertEquals(array(), $this->extension->findMany());

--- a/Tests/Unit/Twig/Extension/CmfExtensionTest.php
+++ b/Tests/Unit/Twig/Extension/CmfExtensionTest.php
@@ -65,6 +65,7 @@ class CmfExtensionTest extends \PHPUnit_Framework_TestCase
             array('getPrev', array('current'), 'getPrev', array('current', null, null, false, null)),
             array('getNext', array('current'), 'getNext', array('current', null, null, false, null)),
             array('find', array('/cms/simple')),
+            array('findTranslation', array('/cms/simple', 'en')),
             array('findMany', array(array('/cms/simple')), 'findMany', array(array('/cms/simple'), false, false, false, null)),
             array('getDescendants', array('parent', 2)),
             array('getNodeName', array('document1')),

--- a/Twig/Extension/CmfExtension.php
+++ b/Twig/Extension/CmfExtension.php
@@ -36,6 +36,7 @@ class CmfExtension extends \Twig_Extension
             new \Twig_SimpleFunction('cmf_prev', array($this, 'getPrev')),
             new \Twig_SimpleFunction('cmf_next', array($this, 'getNext')),
             new \Twig_SimpleFunction('cmf_find', array($this, 'find')),
+            new \Twig_SimpleFunction('cmf_find_translation', array($this, 'findTranslation')),
             new \Twig_SimpleFunction('cmf_find_many', array($this, 'findMany')),
             new \Twig_SimpleFunction('cmf_descendants', array($this, 'getDescendants')),
             new \Twig_SimpleFunction('cmf_nodename', array($this, 'getNodeName')),
@@ -89,6 +90,11 @@ class CmfExtension extends \Twig_Extension
     public function find($path)
     {
         return $this->helper->find($path);
+    }
+
+    public function findTranslation($path, $locale, $fallback = true)
+    {
+        return $this->helper->findTranslation($path, $locale, $fallback);
     }
 
     public function findMany($paths = array(), $limit = false, $offset = false, $ignoreRole = false, $class = null)


### PR DESCRIPTION
Hello there,

This PR just adds a `cmf_find_translation` twig function. Usage example :

```
{% set document = cmf_find_translation('/cms/foo', locale) %}
```