### PR TITLE
[WIP] Extract FormType from Admin

### DIFF
--- a/Admin/Extension/PublishTimePeriodExtension.php
+++ b/Admin/Extension/PublishTimePeriodExtension.php
@@ -13,7 +13,7 @@ namespace Symfony\Cmf\Bundle\CoreBundle\Admin\Extension;
 
 use Sonata\AdminBundle\Admin\AdminExtension;
 use Sonata\AdminBundle\Form\FormMapper;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Cmf\Bundle\CoreBundle\Form\Type\PublishTimePeriodType;
 
 /**
  * Admin extension to add publish workflow time period fields for models
@@ -41,19 +41,11 @@ class PublishTimePeriodExtension extends AdminExtension
      */
     public function configureFormFields(FormMapper $formMapper)
     {
-        $dateOptions = array(
-            'placeholder' => '',
-            'required' => false,
-        );
-
         $formMapper
-            ->with($this->formGroup, array('translation_domain' => 'CmfCoreBundle'))
-                ->add('publish_start_date', DateType::class, $dateOptions, array(
-                    'help' => 'form.help_publish_start_date',
-                ))
-                ->add('publish_end_date', DateType::class, $dateOptions, array(
-                    'help' => 'form.help_publish_end_date',
-                ))
+            ->with($this->formGroup, ['translation_domain' => 'CmfCoreBundle'])
+                ->add('cmf_core_publish_time_period', PublishTimePeriodType::class, [
+                    'inherit_data' => true,
+                ])
             ->end();
     }
 }

--- a/Admin/Extension/PublishableExtension.php
+++ b/Admin/Extension/PublishableExtension.php
@@ -13,7 +13,7 @@ namespace Symfony\Cmf\Bundle\CoreBundle\Admin\Extension;
 
 use Sonata\AdminBundle\Admin\AdminExtension;
 use Sonata\AdminBundle\Form\FormMapper;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Cmf\Bundle\CoreBundle\Form\Type\PublishableType;
 
 /**
  * Admin extension to add a publish workflow publishable field for models
@@ -42,10 +42,11 @@ class PublishableExtension extends AdminExtension
     public function configureFormFields(FormMapper $formMapper)
     {
         $formMapper
-            ->with($this->formGroup, array('translation_domain' => 'CmfCoreBundle'))
-                ->add('publishable', CheckboxType::class, array(
-                    'required' => false,
-                ))
-            ->end();
+            ->with($this->formGroup, ['translation_domain' => 'CmfCoreBundle'])
+                ->add('cmf_core_publishable', PublishableType::class, [
+                    'inherit_data' => true,
+                ])
+            ->end()
+        ;
     }
 }

--- a/Form/Extension/PublishTimePeriodExtension.php
+++ b/Form/Extension/PublishTimePeriodExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Form\Extension;
+
+use Symfony\Cmf\Bundle\CoreBundle\Form\Type\PublishTimePeriodType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class PublishTimePeriodExtension extends AbstractTypeExtension
+{
+    private $extendedType;
+
+    public function __construct($extendedType)
+    {
+        $this->extendedType = $extendedType;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('cmf_core.publish_time_period', PublishTimePeriodType::class, [
+            'inherit_data' => true,
+        ]);
+    }
+
+    public function getExtendedType()
+    {
+        return $this->extendedType;
+    }
+}

--- a/Form/Extension/PublishableExtension.php
+++ b/Form/Extension/PublishableExtension.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class PublishableExtension extends AbstractTypeExtension
+{
+    private $extendedType;
+
+    public function __construct($extendedType)
+    {
+        $this->extendedType = $extendedType;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('cmf_core.publishable', PublishableType::class, [
+            'inherit_data' => true,
+        ]);
+    }
+
+    public function getExtendedType()
+    {
+        return $this->extendedType;
+    }
+}

--- a/Form/Type/PublishTimePeriodType.php
+++ b/Form/Type/PublishTimePeriodType.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class PublishTimePeriodType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('publish_start_date', DateType::class, [
+                'label' => 'form.label_publish_start_date',
+                'translation_domain' => 'CmfCoreBundle',
+                'placeholder' => '',
+                'required' => false,
+            ])
+            ->add('publish_end_date', DateType::class, [
+                'label' => 'form.label_publish_end_date',
+                'translation_domain' => 'CmfCoreBundle',
+                'placeholder' => '',
+                'required' => false,
+            ])
+        ;
+    }
+}

--- a/Form/Type/PublishableType.php
+++ b/Form/Type/PublishableType.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class PublishableType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('publishable', CheckboxType::class, [
+            'required' => false,
+            'label' => 'form.label_publishable',
+            'translation_domain' => 'CmfCoreBundle',
+        ]);
+    }
+}

--- a/Resources/config/form-type.xml
+++ b/Resources/config/form-type.xml
@@ -9,5 +9,9 @@
             <tag name="form.type" alias="cmf_core_checkbox_url_label" />
             <argument type="service" id="router" />
         </service>
+
+        <service id="cmf_core.form.extension.publishable" abstract="true" class="Symfony\Cmf\Bundle\CoreBundle\Form\Extension\PublishableExtension">
+            <!-- <argument /> Extended type fqcn -->
+        </service>
     </services>
 </container>

--- a/Resources/config/form-type.xml
+++ b/Resources/config/form-type.xml
@@ -13,5 +13,9 @@
         <service id="cmf_core.form.extension.publishable" abstract="true" class="Symfony\Cmf\Bundle\CoreBundle\Form\Extension\PublishableExtension">
             <!-- <argument /> Extended type fqcn -->
         </service>
+
+        <service id="cmf_core.form.extension.publish_time_period" abstract="true" class="Symfony\Cmf\Bundle\CoreBundle\Form\Extension\PublishTimePeriodExtension">
+            <!-- <argument /> Extended type fqcn -->
+        </service>
     </services>
 </container>

--- a/Tests/Unit/Admin/Extension/PublishTimePeriodExtensionTest.php
+++ b/Tests/Unit/Admin/Extension/PublishTimePeriodExtensionTest.php
@@ -30,10 +30,9 @@ class PublishTimePeriodExtensionTest extends \PHPUnit_Framework_TestCase
             ->method('with')
             ->with('some_group')
             ->will($this->returnSelf());
-        $this->formMapper->expects($this->exactly(2))
+        $this->formMapper->expects($this->once())
             ->method('add')
             ->will($this->returnSelf());
-
         $this->extension->configureFormFields($this->formMapper);
     }
 }

--- a/Tests/Unit/Admin/Extension/PublishableExtensionTest.php
+++ b/Tests/Unit/Admin/Extension/PublishableExtensionTest.php
@@ -33,7 +33,6 @@ class PublishableExtensionTest extends \PHPUnit_Framework_TestCase
         $this->formMapper->expects($this->exactly(1))
             ->method('add')
             ->will($this->returnSelf());
-
         $this->extension->configureFormFields($this->formMapper);
     }
 }


### PR DESCRIPTION
I extracted a `Form\Type\PublishableType` from `Admin\Extension\PublishableExtension` and a `Form\Type\PublishTimePeriodType` from `Admin\Extension\PublishTimePeriodExtension`.

For each `FormType`, I added a `FormTypeExtension` with an abstract service definition to enable client bundles to easily define their service.
## Progress
### Todo
- [x] fix `Admin\Extension\PublishTimePeriodExtension` tests.
- [x] fix `Admin\Extension\PublishableExtension` tests.
- [x] ~~add missing help texts for `publish_start_date` and `publish_end_date`.~~
- [ ] write `Form\Type\PublishableType` tests.
- [ ] write `Form\Type\PublishTimePeriodType` tests.
- [ ] write `Form\Extension\PublishableExtension` tests
- [ ] write `Form\Extension\PublishTimePeriodExtension` tests
### Blockers
- none
