### PR TITLE
no longer prepend content_basepath in routing configuration

### DIFF
--- a/src/DependencyInjection/CmfCoreExtension.php
+++ b/src/DependencyInjection/CmfCoreExtension.php
@@ -126,7 +126,6 @@ class CmfCoreExtension extends Extension implements PrependExtensionInterface
                                 'persistence' => [
                                     'phpcr' => [
                                         'enabled' => $persistenceConfig['enabled'],
-                                        'content_basepath' => $persistenceConfig['basepath'].'/content',
                                         'route_basepaths' => $routePaths,
                                         'manager_name' => $persistenceConfig['manager_name'],
                                     ],


### PR DESCRIPTION
this routing parameter was only used for sonata admin