### PR TITLE
[BUGFIX] Prevent null-check on get_class occurrence

### DIFF
--- a/PublishWorkflow/Voter/PublishableVoter.php
+++ b/PublishWorkflow/Voter/PublishableVoter.php
@@ -49,7 +49,7 @@ class PublishableVoter implements VoterInterface
      */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
-        if (!$this->supportsClass(get_class($object))) {
+        if ($object === null || !$this->supportsClass(get_class($object))) {
             return self::ACCESS_ABSTAIN;
         }
 

--- a/Tests/Unit/PublishWorkflow/Voter/PublishableVoterTest.php
+++ b/Tests/Unit/PublishWorkflow/Voter/PublishableVoterTest.php
@@ -100,4 +100,14 @@ class PublishableVoterTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals(VoterInterface::ACCESS_ABSTAIN, $result);
     }
+
+    public function testNullObject()
+    {
+        $result = $this->voter->vote(
+            $this->token,
+            null,
+            array()
+        );
+        $this->assertEquals(VoterInterface::ACCESS_ABSTAIN, $result);
+    }
 }


### PR DESCRIPTION
Since PHP's get_class() has the unlucky ability to pass null
(resp. nothing) as argument and considers the calling class
in this case which leads to side effects; and PHP 7.2 doesn't
allow null values at all anymore; this change fixes a case
where this might happen as of the interface since a null
object can be passed.

| Q             | A
| ------------- | ---
| Branch?       | 1.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 
