### PR TITLE
Add symfony/security-core to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0"
+        "symfony/framework-bundle": "^2.8 || ^3.3 || ^4.0",
+        "symfony/security-core": "^2.8 || ^3.3 || ^4.0"
     },
     "require-dev": {
         "symfony/security-bundle": "^2.8 || ^3.3 || ^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master", for 2.1 release
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

In https://github.com/symfony-cmf/symfony-cmf/issues/260 i tried to create minimal recipes for SymfonyCMF bundles used in `symfony-cmf/symfony-cmf`

A recipe for `symfony-cmf/core-bundle` could could contain these lines:

```yaml
cmf_core:
    persistence:
        phpcr:
            enabled: true
```

With this PR `symfony/security-core` package will be installed with `symfony-cmf/core-bundle` for `Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\AlwaysPublishedWorkflowChecker` service, loaded from [no-publish-workflow.xml](https://github.com/symfony-cmf/core-bundle/blob/master/src/Resources/config/no-publish-workflow.xml)
