### PR TITLE
bump bridge version to avoid problem with lowest version install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony/security-bundle": "^2.8 || ^3.3 || ^4.0",
-        "symfony/phpunit-bridge": "^3.3 || ^4.0",
+        "symfony/phpunit-bridge": "^3.4.19 || ^4.0",
         "mockery/mockery": "^0.9.4",
         "symfony-cmf/routing-bundle": "^2.1.0",
         "symfony-cmf/testing": "^2.1.8",


### PR DESCRIPTION
build started failing because phpunit bridge 3.3.0 tries to download a phpunit .zip file that no longer exists.

up to the latest 3.x version - this is a require-dev dependency and therefor irrelevant for our users.