### PR TITLE
upgrade to PHP8

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -30,6 +30,9 @@ jobs:
                     - php-version: '7.4'
                       symfony-version: 5.0.*
                       test-installation: true
+                    - php-version: '8.0'
+                      symfony-version: 5.1.*
+                      test-installation: true
 
         steps:
             - name: Checkout project

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4 || ^8.0",
         "symfony/framework-bundle": "^4.4 || ^5.0",
         "symfony/security-core": "^4.4 || ^5.0"
     },
@@ -22,7 +22,7 @@
         "jackalope/jackalope-doctrine-dbal": "^1.3",
         "symfony/security-bundle": "^4.4 || ^5.0",
         "symfony/phpunit-bridge": "^4.4.34 || ^5.0",
-        "mockery/mockery": "^0.9.4",
+        "mockery/mockery": "^1.4.1",
         "symfony-cmf/routing-bundle": "^2.1.0",
         "symfony-cmf/testing": "^4.0.0",
         "doctrine/dbal": "^2.5",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,7 @@
 
     <php>
         <server name="KERNEL_CLASS" value="\Symfony\Cmf\Bundle\CoreBundle\Tests\Fixtures\App\Kernel" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=52"/>
     </php>
 
 </phpunit>

--- a/tests/Fixtures/App/config/config.php
+++ b/tests/Fixtures/App/config/config.php
@@ -17,5 +17,5 @@ $loader->import(__DIR__.'/cmf_routing.yml');
 $loader->import(__DIR__.'/config.yml');
 
 $container->loadFromExtension('framework', [
-    'csrf_protection' => true,
+    'csrf_protection' => false,
 ]);

--- a/tests/Functional/Form/CheckboxUrlLabelFormTypeTest.php
+++ b/tests/Functional/Form/CheckboxUrlLabelFormTypeTest.php
@@ -30,7 +30,7 @@ class CheckboxUrlLabelFormTypeTest extends BaseTestCase
 
     public function testFormTwigTemplate()
     {
-        $view = $this->getContainer()->get('form.factory')->createNamedBuilder('name')
+        $view = $this->getContainer()->get('test.service_container')->get('form.factory')->createNamedBuilder('name')
             ->add('terms', CheckboxUrlLabelFormType::class, [
                 'label' => '%a% and %b% and %c%',
                 'routes' => [
@@ -51,7 +51,7 @@ class CheckboxUrlLabelFormTypeTest extends BaseTestCase
      */
     private function getFormRenderer()
     {
-        $twig = $this->getContainer()->get('twig');
+        $twig = $this->getContainer()->get('test.service_container')->get('twig');
 
         // BC for Symfony < 3.2 where this runtime does not exists
         if (!method_exists(AppVariable::class, 'getToken')) {

--- a/tests/Functional/PublishWorkflow/PublishWorkflowTest.php
+++ b/tests/Functional/PublishWorkflow/PublishWorkflowTest.php
@@ -15,6 +15,7 @@ use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface;
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodReadInterface;
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
 use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -25,9 +26,15 @@ class PublishWorkflowTest extends BaseTestCase
      */
     private $publishWorkflowChecker;
 
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
     public function setUp(): void
     {
         $this->publishWorkflowChecker = $this->getContainer()->get('cmf_core.publish_workflow.checker');
+        $this->tokenStorage = $this->getContainer()->get('test.service_container')->get('security.token_storage');
     }
 
     public function testPublishable()
@@ -69,8 +76,7 @@ class PublishWorkflowTest extends BaseTestCase
             'ROLE_CAN_VIEW_NON_PUBLISHED',
         ];
         $token = new UsernamePasswordToken('test', 'pass', 'testprovider', $roles);
-        $tokenStorage = $this->getContainer()->get('security.token_storage');
-        $tokenStorage->setToken($token);
+        $this->tokenStorage->setToken($token);
 
         $this->assertTrue($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $doc));
         $this->assertFalse($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $doc));
@@ -87,8 +93,7 @@ class PublishWorkflowTest extends BaseTestCase
             'OTHER_ROLE',
         ];
         $token = new UsernamePasswordToken('test', 'pass', 'testprovider', $roles);
-        $tokenStorage = $this->getContainer()->get('security.token_storage');
-        $tokenStorage->setToken($token);
+        $this->tokenStorage->setToken($token);
 
         $this->assertFalse($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ATTRIBUTE, $doc));
         $this->assertFalse($this->publishWorkflowChecker->isGranted(PublishWorkflowChecker::VIEW_ANONYMOUS_ATTRIBUTE, $doc));

--- a/tests/Functional/Twig/ServiceTest.php
+++ b/tests/Functional/Twig/ServiceTest.php
@@ -19,7 +19,7 @@ class ServiceTest extends BaseTestCase
     public function testContainer()
     {
         /** @var \Twig\Environment $twig */
-        $twig = $this->getContainer()->get('twig');
+        $twig = $this->getContainer()->get('test.service_container')->get('twig');
         $ext = $twig->getExtension(method_exists($twig, 'getRuntime') ? CmfExtension::class : 'cmf');
         $this->assertNotEmpty($ext);
     }

--- a/tests/Unit/Templating/Helper/CmfTest.php
+++ b/tests/Unit/Templating/Helper/CmfTest.php
@@ -67,16 +67,10 @@ class CmfTest extends TestCase
     {
         $document = new \stdClass();
 
-        $this->uow->expects($this->at(0))
+        $this->uow->expects(self::exactly(2))
             ->method('getDocumentId')
-            ->with($document)
-            ->will($this->throwException(new \Exception()))
-        ;
-
-        $this->uow->expects($this->at(1))
-            ->method('getDocumentId')
-            ->with($document)
-            ->will($this->returnValue('/foo/bar'))
+            ->withConsecutive([$document], [$document])
+            ->willReturnOnConsecutiveCalls($this->throwException(new \Exception()), $this->returnValue('/foo/bar'))
         ;
 
         $this->assertFalse($this->helper->getNodeName($document));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | yes
| Fixed tickets | /
| License       | MIT
| Doc PR        | /

@dbu @esserj this PR is for upgrading core-bundle to support PHP8. 

You will see that SYMFONY_DEPRECATIONS_HELPER is changed to max[direct]=52 as we've tested it in Symfony 5.4, there are a lot of deprecations which should be fixed when upgrading to Symfony 6.0+, I have tried to battle these deprecations but It would require too much time to update these as they would require me to update a lot of sub dependencies/packages. I feel like these should not be fixed in the Symfony 5 upgrade