### PR TITLE
Previously we set the value of allowIfAllAbstainDecisions to true, this was not ported to the UnanimousStrategy service

### DIFF
--- a/src/Resources/config/publish-workflow.xml
+++ b/src/Resources/config/publish-workflow.xml
@@ -6,7 +6,10 @@
 
     <services>
 
-        <service id="cmf_core.publish_workflow.access_decision_manager.strategy" class="Symfony\Component\Security\Core\Authorization\Strategy\UnanimousStrategy"/>
+        <service id="cmf_core.publish_workflow.access_decision_manager.strategy" class="Symfony\Component\Security\Core\Authorization\Strategy\UnanimousStrategy">
+            <argument>true</argument>
+        </service>
+
         <service id="cmf_core.publish_workflow.access_decision_manager" class="Symfony\Component\Security\Core\Authorization\AccessDecisionManager">
             <argument type="collection"/>
             <argument type="service" id="cmf_core.publish_workflow.access_decision_manager.strategy"/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x for new features / the branch of the current release for fixes
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | reference to the documentation PR, if any

There was a bc break in the SF6 compatibility fixes in https://github.com/symfony-cmf/core-bundle/pull/285/files#diff-1321e425c72f090b283c6b80c2dc411e7e1d60b47f144ed1b5bf11e04177386fR9. We created the UnanimousStrategy service as string strategy names were deprecated. But the `allowIfAllAbstainDecisions` value passed to the `Symfony\Component\Security\Core\Authorization\AccessDecisionManager` was not ported to that service. Resulting in previously having it `true` and now `false`. This PR fixes that BC break